### PR TITLE
Enable external ingress

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -12,5 +12,5 @@ ingress:
     enabled: true
     host: engineering.internal.sas.homeoffice.gov.uk
   external:
-    enabled: false
+    enabled: true
     host: engineering.homeoffice.gov.uk


### PR DESCRIPTION
Links to #213 

Enable the external ingress to allow for the `engineering.homeoffice.gov.uk` domain.

# Code change
I can confirm:
## Accessibility considerations
- [X] This change will not change layouts, page structures or anything else that might impact accessibility