### PR TITLE
Remove solver for external ingress

### DIFF
--- a/helm/templates/ingress-external.yaml
+++ b/helm/templates/ingress-external.yaml
@@ -4,8 +4,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "app.name" . }}-external
-  labels:
-    cert-manager.io/solver: route53
   annotations:
     cert-manager.io/enabled: "true"
     ingress.kubernetes.io/force-ssl-redirect: "true"


### PR DESCRIPTION
As the DNS zone hasn't been delegated for the domain, the route53 solver cannot be used. This change removes this, falling back to the default.

# Code change
I can confirm:
## Accessibility considerations
- [x] This change will not change layouts, page structures or anything else that might impact accessibility