### PR TITLE
Explicitly specify cert-manager solver

### DIFF
--- a/helm/templates/ingress-external.yaml
+++ b/helm/templates/ingress-external.yaml
@@ -4,6 +4,8 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ include "app.name" . }}-external
+  labels:
+    cert-manager.io/solver: "http01"
   annotations:
     cert-manager.io/enabled: "true"
     ingress.kubernetes.io/force-ssl-redirect: "true"


### PR DESCRIPTION
While our hosting platform defaults to `http01` solver when the label isn't specified. It is still required by the schema when the cert-manager is enabled. This change adds this explicitly in.

# Code change
I can confirm:
## Accessibility considerations
- [X] This change will not change layouts, page structures or anything else that might impact accessibility