### PR TITLE
Create CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,12 @@
+# Default ownership - @ukhomeoffice/segas-admins own all 
+# files in the repository unless a later match takes precedence
+# and will be requested for review when a pull request is opened
+*       @UKHomeOffice/segas-admins
+
+# @ukhomeoffice/segas-engineering-principals own all
+# standards, patterns and principles. They will be requested for
+# review if a pull request is opened touching a file in these
+# directories, or their subdirectories
+/docs/patterns/ @UKHomeOffice/segas-engineering-principals
+/docs/standards/ @UKHomeOffice/segas-engineering-principals
+/docs/principles/ @UKHomeOffice/segas-engineering-principals


### PR DESCRIPTION
Assigns default ownership across the repository to segas-admins
Assigns specific ownership of standards, principles and patterns to segas-engineering-principals

Branch protection to be reconfigured on main to require review by codeowning teams when pattern in CODEOWNERS is matched

Is this pull request a content or a code change? (Please fill in the relevant section and delete the other)

# Code change
I can confirm:

- [x] This change will not change layouts, page structures or anything else that might impact accessibility
