### PR TITLE
SEGAS-00003: Added line to require naming SRO in product documentation

### DIFF
--- a/docs/standards/minimal-documentation-set-for-a-product.md
+++ b/docs/standards/minimal-documentation-set-for-a-product.md
@@ -24,10 +24,11 @@ A product should be documented to a minimum standard so that new engineers can b
 
 ### Product documentation MUST include a description of the product and what it is for
 
-The description should provide domain context to an engineer and link to product documentation, for example:
+The description should provide domain context to an engineer and link to product documentation, including:
 
 - Information about the team
 - Key stakeholders
+- Who the [Senior Responsible Owner (SRO)](https://www.gov.uk/government/publications/the-role-of-the-senior-responsible-owner/the-role-of-the-senior-responsible-owner) is
 - User research findings
 - Product roadmap
 - Business analysis findings

--- a/docs/standards/minimal-documentation-set-for-a-product.md
+++ b/docs/standards/minimal-documentation-set-for-a-product.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Minimal documentation set for a product
-date: 2023-06-13
+date: 2023-10-26
 id: SEGAS-00003
 tags:
 - Documentation


### PR DESCRIPTION
Will close #314 

# Content change 
- [x] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [x] Content does not include any code or configuration changes (excluding frontmatter information)
- [x] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [x] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [x] Last updated date for content is correct
