### PR TITLE
Set site root when building docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ COPY . .
 RUN apk update && apk upgrade && \
     apk add --no-cache git
 
+ENV SITE_ROOT "https://engineering.homeoffice.gov.uk/"
+
 RUN npm ci --omit=dev
 RUN npm run build
 


### PR DESCRIPTION
The SITE_ROOT env variable needs to be set to the expected root of the site when the static pages are being built by 11ty.

# Code change
I can confirm:
## Accessibility considerations
- [x] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [x] This change will not change layouts, page structures or anything else that might impact accessibility
