### PR TITLE
Removed tech debt related to path prefix usages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -2,8 +2,6 @@ const govukEleventyPlugin  = require('@x-govuk/govuk-eleventy-plugin')
 const { DateTime } = require("luxon");
 
 module.exports = function(eleventyConfig) {
-    // Set custom variable to decide the path prefix as it is used in a couple of places.
-    const _customPathPrefix = process.env.PATH_PREFIX ?? '';
     const _siteRoot = process.env.SITE_ROOT ?? 'http://localhost/';
     // Pass assets through to final build directory
     eleventyConfig.addPassthroughCopy({ "docs/assets/logos": "assets/logos"});
@@ -19,7 +17,7 @@ module.exports = function(eleventyConfig) {
         opengraphImageUrl: '/assets/logos/ho-opengraph-image.png',
         homeKey: 'Home',
         header: {
-            organisationLogo: '<img src="' + _customPathPrefix + '/assets/logos/ho_logo.svg" height="34px" alt="Home Office Logo">',
+            organisationLogo: '<img src="/assets/logos/ho_logo.svg" height="34px" alt="Home Office Logo">',
             organisationName: 'Home Office',
             productName: 'Engineering Guidance and Standards',
             search: {
@@ -35,15 +33,15 @@ module.exports = function(eleventyConfig) {
             meta: {
                 items: [
                     {
-                        href: _customPathPrefix + '/about/',
+                        href: '/about/',
                         text: 'About'
                     },
                     {
-                        href: _customPathPrefix + '/cookies/',
+                        href: '/cookies/',
                         text: 'Cookies'
                     },
                     {
-                        href: _customPathPrefix + '/accessibility-statement/',
+                        href: '/accessibility-statement/',
                         text: 'Accessibility'
                     },
                     {
@@ -65,18 +63,6 @@ module.exports = function(eleventyConfig) {
         md.use(require('./lib/markdown/dl-as-govuk-summary-list'));
 
         eleventyConfig.setLibrary('md', md);
-    })
-
-    eleventyConfig.addFilter("itemsFromPaginationWithPathPrefix", (pagination) => {
-      const items = []
-      pagination.pages.forEach((item, index) => {
-        items.push({
-          current: index === pagination.pageNumber,
-          number: index + 1,
-          href: _customPathPrefix + pagination.hrefs[index]
-        })
-      })
-      return items;
     });
 
     eleventyConfig.addFilter("postDate", (dateObj) => {
@@ -142,11 +128,10 @@ module.exports = function(eleventyConfig) {
         tag: {
           text: "Alpha"
         },
-        html: 'This is a new service – your <a class="govuk-link" target="_blank" href="' + _customPathPrefix + '/provide-feedback/">feedback (opens in a new tab)</a> will help us to improve it.'
+        html: 'This is a new service – your <a class="govuk-link" target="_blank" href="/provide-feedback/">feedback (opens in a new tab)</a> will help us to improve it.'
       }
     });
 
-    eleventyConfig.addGlobalData('pathPrefix', _customPathPrefix);
     eleventyConfig.addGlobalData('siteRoot', _siteRoot);
 
     return {
@@ -158,7 +143,6 @@ module.exports = function(eleventyConfig) {
             layouts: '../_includes/layouts',
             includes: '../_includes',
             input: 'docs'
-        },
-        pathPrefix: _customPathPrefix
+        }
     }
 };

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -9,7 +9,6 @@ on:
 env:
   TEST_URL: localhost
   TEST_PORT: 8080
-  TEST_PATH_PREFIX: '/test/'
 
 jobs:
   e2e-test:
@@ -29,10 +28,8 @@ jobs:
           browser: chrome
           build: npm run build
           start: npm run serve -- --port ${{ env.TEST_PORT }}
-          wait-on: 'http://${{ env.TEST_URL }}:${{ env.TEST_PORT }}${{ env.TEST_PATH_PREFIX }}'
+          wait-on: 'http://${{ env.TEST_URL }}:${{ env.TEST_PORT }}'
           config: 'video=false,screenshotOnRunFailure=false'
         env:
           CYPRESS_TEST_URL: ${{ env.TEST_URL }}
           CYPRESS_TEST_PORT: ${{ env.TEST_PORT }}
-          CYPRESS_TEST_PATH_PREFIX: ${{ env.TEST_PATH_PREFIX }}
-          PATH_PREFIX: ${{ env.TEST_PATH_PREFIX }}

--- a/_data/eleventyComputed.js
+++ b/_data/eleventyComputed.js
@@ -1,44 +1,6 @@
-// noinspection JSUnusedGlobalSymbols
-const { applyBaseToUrl } = require('@11ty/eleventy/src/Plugins/HtmlBasePlugin')
-
-function mapRelatedSections(sections, pathPrefix) {
-  return sections.map(
-    section => ({
-      ...section,
-      items: (section.items ?? []).map(item => ({
-        ...item,
-        href: applyBaseToUrl(item.href, pathPrefix, {pathPrefix}),
-      })),
-      subsections: mapRelatedSections(section.subsections ?? [], pathPrefix),
-    })
-  );
-}
-
 module.exports = {
   eleventyExcludeFromCollections: ({page, eleventyExcludeFromCollections}) => {
     return eleventyExcludeFromCollections || page.templateSyntax === 'scss';
-  },
-  // the path prefix isn't applied to related link urls by xGovukRelatedNavigation - so map them here
-  pagination: ({pagination, pathPrefix}) => {
-    if (!pagination || Object.keys(pagination).length === 0) {
-      return pagination;
-    }
-    if (pagination.href.previous) {
-      pagination.href.previous = applyBaseToUrl(pagination.href.previous, pathPrefix, {pathPrefix});
-    }
-    if (pagination.href.next) {
-      pagination.href.next = applyBaseToUrl(pagination.href.next, pathPrefix, {pathPrefix});
-    }
-    return pagination;
-  },
-  related: ({related, pathPrefix}) => {
-    if (!related) {
-      return related;
-    }
-
-    related.sections = mapRelatedSections(related.sections ?? [related], pathPrefix);
-
-    return related;
   }
 }
 

--- a/_includes/layouts/collection.njk
+++ b/_includes/layouts/collection.njk
@@ -50,7 +50,7 @@
       next: {
         href: pagination.href.next
       },
-      items: pagination | itemsFromPaginationWithPathPrefix
+      items: pagination | itemsFromPagination
     }) if pagination.pages.length > 1 }}
   </section>
 

--- a/_includes/layouts/tags.njk
+++ b/_includes/layouts/tags.njk
@@ -22,15 +22,7 @@
 
       <ul class="govuk-list govuk-list--bullet">
        {% for tag in collections.all | getAllTags | filterTagList %}
-        {% if tag == "Patterns" %}
-          {%- set tagUrl %}{{ "/patterns/" | url }}/{% endset %}
-        {% elseif tag == "Principles" %}
-          {%- set tagUrl %}{{ "/principles/" | url }}/{% endset %}
-        {% elseif tag == "Standards" %}
-         {%- set tagUrl %}{{ "/standards" | url }}/{% endset %}
-        {% else %}
-         {%- set tagUrl %}{{ "/tags/" | url }}{{ tag | slugify }}/{% endset %}
-        {% endif %}
+       {%- set tagUrl %}{{ "/tags/" | url }}{{ tag | slugify }}/{% endset %}
         <li>
           <a href="{{ tagUrl }}">{{ tag }}</a>
         </li>

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -114,7 +114,7 @@ describe('Cookies page links from footer test', () => {
   })
 })
 
-describe('Related links respect path prefix', () => {
+describe('Related links', () => {
   it('finds the correct related link and follows it to a valid page', () => {
     cy.visit(testing_params.TEST_ROOT_URL)
     // Click through to standard page that has a related link
@@ -126,7 +126,7 @@ describe('Related links respect path prefix', () => {
   })
 })
 
-describe('Pagination links respect path prefix', () => {
+describe('Pagination links', () => {
   it('finds the pagination links and follows them to valid pages', () => {
     cy.visit(testing_params.TEST_ROOT_URL)
     // Click to standards page that has a related link


### PR DESCRIPTION
Removed tech debt related to path prefix usages.
Path prefix is no longer required due to the site being hosted at the root of the engineering.homeoffice.gov.uk domain

# Code change
I can confirm:
## Accessibility considerations
- [x] This change will not change layouts, page structures or anything else that might impact accessibility