### PR TITLE
Add content category for items in tag page

### DIFF
--- a/_includes/layouts/tag.njk
+++ b/_includes/layouts/tag.njk
@@ -24,7 +24,8 @@
     {{ documentList.contentDocumentList({
       headingLevel: 3 if paginationHeading else 2,
       classes: "app-document-list--large",
-      items: collections[tag] | orderPagesByTitle
+      items: collections[tag] | orderPagesByTitle,
+      displayContentCategory: true
     }) }}
 
     {{ appProseScope(content) if content }}

--- a/_includes/macros/contentDocumentList.njk
+++ b/_includes/macros/contentDocumentList.njk
@@ -17,7 +17,7 @@
       {% if item.data.date or item.data.tags %}
       <ul class="app-document-list__item-metadata">
         {% if params.displayContentCategory === true and item.data.category %}
-        <li class="app-document-list__attribute">
+        <li class="app-document-list__attribute document-category">
           {{ item.data.category }}
         </li>
         {% endif %}

--- a/_includes/macros/contentDocumentList.njk
+++ b/_includes/macros/contentDocumentList.njk
@@ -16,6 +16,11 @@
       {% endif %}
       {% if item.data.date or item.data.tags %}
       <ul class="app-document-list__item-metadata">
+        {% if params.displayContentCategory === true and item.data.category %}
+        <li class="app-document-list__attribute">
+          {{ item.data.category }}
+        </li>
+        {% endif %}
         {% if item.data.id %}
         <li class="app-document-list__attribute">
           {{ item.data.id }}

--- a/cypress/e2e/spec.cy.js
+++ b/cypress/e2e/spec.cy.js
@@ -139,3 +139,35 @@ describe('Pagination links respect path prefix', () => {
     cy.contains('h1', 'Principles')
   })
 })
+
+describe('Content category displays in correct listing pages', () => {
+  it('finds the content category in tag page', () => {
+    cy.visit(testing_params.TEST_ROOT_URL + '/tags/ways-of-working/')
+    cy.get('ol.app-document-list').find('.document-category')
+      .its('length').should('be.gte', 5)
+  })
+
+  it('does not find the content category in principles page', () => {
+    cy.visit(testing_params.TEST_ROOT_URL)
+    cy.contains('Read our principles').click()
+    // No .document-category listed in this page
+    cy.get('ol.app-document-list').find('.document-category')
+      .should('have.length', 0)
+  })
+
+  it('does not find the content category in standards page', () => {
+    cy.visit(testing_params.TEST_ROOT_URL)
+    cy.contains('Read our standards').click()
+    // No .document-category listed in this page
+    cy.get('ol.app-document-list').find('.document-category')
+      .should('have.length', 0)
+  })
+
+  it('does not find the content category in patterns page', () => {
+    cy.visit(testing_params.TEST_ROOT_URL)
+    cy.contains('Read our patterns').click()
+    // No .document-category listed in this page
+    cy.get('ol.app-document-list').find('.document-category')
+      .should('have.length', 0)
+  })
+})

--- a/docs/patterns/patterns.11tydata.js
+++ b/docs/patterns/patterns.11tydata.js
@@ -1,5 +1,6 @@
 module.exports = {
   tags: [],
+  category: 'Pattern',
   eleventyComputed: {
     viewSource: data => `./docs${data.page.filePathStem}.md?plain=1`
   },

--- a/docs/principles/principles.11tydata.js
+++ b/docs/principles/principles.11tydata.js
@@ -1,5 +1,6 @@
 module.exports = {
     tags: [],
+    category: 'Principle',
     eleventyComputed: {
         viewSource: data => `./docs${data.page.filePathStem}.md?plain=1`
     },

--- a/docs/standards/standards.11tydata.js
+++ b/docs/standards/standards.11tydata.js
@@ -1,5 +1,6 @@
 module.exports = {
   tags: [],
+  category: 'Standard',
   eleventyComputed: {
     viewSource: data => `./docs${data.page.filePathStem}.md?plain=1`
   },


### PR DESCRIPTION
Added content category for items in tag page.

See below for preview:

![Screenshot 2023-11-06 at 08 53 04](https://github.com/UKHomeOffice/engineering-guidance-and-standards/assets/133027753/85fee8b4-edd4-4aca-bfc5-b79e1293ddd2)

---

# Code change
I can confirm:
## Accessibility considerations
- [x] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [x] This change might impact accessibility, automated aXe tests cover the impact

