### PR TITLE
Update accessibility to WCAG 2.2

### DIFF
--- a/cypress/e2e/a11y.spec.cy.js
+++ b/cypress/e2e/a11y.spec.cy.js
@@ -2,6 +2,16 @@ import {testing_params} from "../support/testing_params";
 
 import pages from "../../_site/search.json"
 
+const axeConfig = {
+  // There are occasional contrast false-positives if the page isn't fully loaded
+  retries: 1,
+  interval: 100,
+  // WCAG 2.2 isn't included by default - only the target size check is automated by axe
+  rules: {
+    'target-size': { enabled: true },
+  },
+}
+
 function terminalLog(violations) {
   const totalNodes = violations.reduce((acc, v) => acc + v.nodes.length, 0);
 
@@ -31,7 +41,7 @@ describe('All pages pass axe-core accessibility checks', () => {
     it(`${page.title} (${page.url}) is accessible`, () => {
       cy.visit(testing_params.TEST_ROOT_URL + page.url)
       cy.injectAxe()
-      cy.checkA11y({exclude: '[data-axe-exclude]'}, null, terminalLog);
+      cy.checkA11y({exclude: '[data-axe-exclude]'}, axeConfig, terminalLog);
     })
 
     titles[page.title] = [
@@ -69,16 +79,16 @@ describe('Tag pages pass axe-core accessibility checks', () => {
     cy.contains('Minimal documentation set for a product').click()
     cy.get('.tags').contains('Documentation').click()
     cy.injectAxe()
-    cy.checkA11y({exclude: '[data-axe-exclude]'}, null, terminalLog);
+    cy.checkA11y({exclude: '[data-axe-exclude]'}, axeConfig, terminalLog);
   })
 
-  it('All tags is accessible', () => {
+  it('All tags page is accessible', () => {
     cy.visit(testing_params.TEST_ROOT_URL)
     cy.contains('Read our standards').click()
     cy.contains('Minimal documentation set for a product').click()
     cy.get('.tags').contains('Documentation').click()
     cy.contains('all tags').click()
     cy.injectAxe()
-    cy.checkA11y({exclude: '[data-axe-exclude]'}, null, terminalLog);
+    cy.checkA11y({exclude: '[data-axe-exclude]'}, axeConfig, terminalLog);
   })
 })

--- a/docs/accessibility-statement.md
+++ b/docs/accessibility-statement.md
@@ -55,7 +55,7 @@ The Home Office is committed to making its website accessible, in accordance wit
 
 ### Compliance status
 
-This website is compliant with the [Web Content Accessibility Guidelines version 2.1](https://www.w3.org/TR/WCAG21/) AA standard.
+This website is compliant with the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG22/) AA standard.
 
 Contributions to the site are managed using the [engineering guidance and standards repository on GitHub](https://github.com/UKHomeOffice/engineering-guidance-and-standards). This is partially compliant as described in [GitHub's accessibility conformance report](https://accessibility.github.com/conformance/github-com/). 
 
@@ -67,8 +67,8 @@ Contributing to the site using the [engineering guidance and standards repositor
 
 ## Preparation of this accessibility statement
 
-- This statement was prepared and reviewed on 27th October 2023.
-- This website was last tested on 28th September 2023. Testing was carried out internally by the Home Office.
+- This statement was prepared and reviewed on 27th December 2023.
+- This website was last tested on 27th December 2023. Testing was carried out internally by the Home Office.
 
 We test this site as it develops by running automated accessibility tests provided by [`axe-core`](https://github.com/dequelabs/axe-core) on all changes, and by following a script of manual checks to perform when reviewing changes to the site. These are stored in GitHub:
 

--- a/docs/styles/base.scss
+++ b/docs/styles/base.scss
@@ -37,3 +37,8 @@
 .govuk-header label.govuk-visually-hidden {
   color: black;
 }
+
+.govuk-breadcrumbs__link {
+  display: inline-block;
+  min-height: 24px;
+}

--- a/technical-docs/accessibility/layout-checks.md
+++ b/technical-docs/accessibility/layout-checks.md
@@ -20,8 +20,7 @@ checked as part of the review process.
 
 Then open up example pages that will be affected by your layout changes. For each:
 
-- [ ] Tab through the focusable elements of the page. Is it clear what has focus, and does focus progress in a logical 
-  order?
+- [ ] Tab through the focusable elements of the page. Is it clear what has focus, is anything obscuring the focussed element, and does focus progress in a logical order?
     - By default, on macOS tab navigation doesn't reach all links. You will need to turn on the keyboard navigation in Settings -> Keyboard to perform this step on a MacBook.
 - [ ] The first item before the menu should be a link to skip to the main content, which is only visible when focussed. Check this navigates to the start of the page's main content.
 - [ ] Are blocks of text left-aligned?
@@ -33,10 +32,12 @@ Then open up example pages that will be affected by your layout changes. For eac
 
 ## Assumptions
 
-This checklist is a reduced list compared to the full WCAG v2.1 criteria. They have been chosen based on the assumptions:
+This checklist is a reduced list compared to the full WCAG v2.2 criteria. They have been chosen based on the assumptions:
 
 - That the engineering guidance and standards site will remain a static documentation site. 
 - That principles, standards, and patterns will be structured text, with some images and diagrams.
 - That there are no interactive components on the site except the site search and hyperlinks.
+- That there are no banners or modals that will cover other elements.
+- The site does not require authentication, and there are no other forms that accept user input.
 
 If these assumptions no longer hold, you should check the changes against the full criteria set. A copy of the current WCAG AA criteria can be found in the [Accessibility guidelines of the Home Office design system](https://design.homeoffice.gov.uk/accessibility/standard).


### PR DESCRIPTION
Is this pull request a content or a code change? (Please fill in the relevant section and delete the other)

# Code change
I can confirm:
## Accessibility considerations
- [X] This change might impact accessibility and is not covered by automated aXe tests - manual testing has been performed

Review of site and accessibility guidance to bring it up to compliance with WCAG 2.2.

WCAG2.2 changes: https://www.w3.org/WAI/standards-guidelines/wcag/new-in-22/

- [X] 2.4.11 Focus Not Obscured (Minimum) (AA)
    - We don't have banners/modals/other elements that appear over the page content
    - Updated layout accessibility guidance to indicate this assumption
- [X] 2.5.7 Dragging Movements (AA) 
    - The site is not interactive in this way - covered by existing assumption statements
- [x] 2.5.8 Target Size (Minimum) (AA)
    - `axe-core` has an automated check for this, which has been explicitly enabled as it's off by default at the moment.
    - ~~The breadcrumbs are failing this on `/standards/managing-secrets/`, `/standards/signing-code-commits/`, and `/patterns/using-generative-ai/` - which looks to be an axe bug as they display the same as other pages that pass, and adding space doesn't help.~~ Resolved, forced breadcrumbs to minimum 24px tall.
- [x] 3.2.6 Consistent Help (A)
    - There is a feedback link in the phase banner which is in the same place on all pages  ✅ 
    - There is accessibility link in the footer that is consistent across all pages ✅ 
    - Question: do we want a more explicit get help link in the footer?
- [X] 3.3.7 Redundant Entry (A)
    - The site doesn't provide forms for users to submit
    - Updated layout accessibility guidance to indicate this assumption
- [X] 3.3.8 Accessible Authentication (Minimum) (AA)
    - The site does not have any authentication
    - Updated layout accessibility guidance to indicate this assumption
