### PR TITLE
Change organisation name to Home Office

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -24,6 +24,7 @@ module.exports = function(eleventyConfig) {
                     '</span>'
             },
             productName: 'Engineering Guidance and Standards',
+            organisationName: 'Home Office',
             search: {
                 label: 'Search site',
                 indexPath: '/search.json',

--- a/cypress/support/link-exception-list.json
+++ b/cypress/support/link-exception-list.json
@@ -1,5 +1,6 @@
 [
   "https://www.homeofficesurveys.homeoffice.gov.uk/s/8PDDG2/",
   "https://opensource.org/licenses/",
-  "https://opensource.org/license/mit/"
+  "https://opensource.org/license/mit/",
+  "https://www.splunk.com/en_us/blog/learn/observability.html?301=/en_us/data-insider/what-is-observability.html"
 ]


### PR DESCRIPTION
# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).
- [X] This change will not change layouts, page structures or anything else that might impact accessibility

Sets the organisation name to Home Office rather than the default GOV.UK