### PR TITLE
#376 - Add logging standards from MBTP

### DIFF
--- a/docs/patterns/securing-application-logging.md
+++ b/docs/patterns/securing-application-logging.md
@@ -19,7 +19,7 @@ related:
 ---
 
 It is common to log user information from an application to assist operations or debugging. Some middleware might be configured to log full configuration, data, or request/response objects, which may contain Personally Identifiable Information (PII), authentication tokens or application secrets.
-
+  
 Logging any of these can make information available to people that have access to log aggregation platforms, or log storage, but are not legally allowed to view PII, or should not otherwise have access to that information. User authentication tokens and application secrets can be used to impersonate users and elevate privilege.
 
 [Sensitive Data Exposure](https://owasp.org/www-project-top-ten/2017/A3_2017-Sensitive_Data_Exposure) has been a recognised risk to secure application development historically. Our [managing secrets]({{ '/standards/managing-secrets/' | url }}) standard has requirements on ensuring logs do not contain tokens or other secrets.
@@ -67,14 +67,14 @@ Logging full payloads should be avoided. However, logging full payloads can be u
 
 ### Consider how information can combine to form PII
 
-Examples of PII include:
+Examples of combined PII include:
 * Passport number, Issuing Country, Expiry Dates
 * BRP/C number, Date of Birth
-
-With the examples above, the information by themselves do not mean very much, after all a BRP/C number is just a "random" sequence of characters; but in combination with the date of birth it can be used to uniquely identify an individual.
-
+  
+With the examples above, the information by themselves do not mean very much. After all, a BRP/C number is just a "random" sequence of characters; but in combination with the date of birth it can be used to uniquely identify an individual.
+  
 If you are unsure what is person identifiable information, consult with your security specialists.
-
+  
 Information and data sets that contain sensitive information should not be output to logs regardless of log level.
 
 ### Consider whether logging statements are necessary

--- a/docs/patterns/securing-application-logging.md
+++ b/docs/patterns/securing-application-logging.md
@@ -65,6 +65,18 @@ Logging full payloads should be avoided. However, logging full payloads can be u
 
 ## Considerations
 
+### Consider how information can combine to form PII
+
+Examples of PII include:
+* Passport number, Issuing Country, Expiry Dates
+* BRP/C number, Date of Birth
+
+With the examples above, the information by themselves do not mean very much, after all a BRP/C number is just a "random" sequence of characters; but in combination with the date of birth it can be used to uniquely identify an individual.
+
+If you are unsure what is person identifiable information, consult with your security specialists.
+
+Information and data sets that contain sensitive information should not be output to logs regardless of log level.
+
 ### Consider whether logging statements are necessary
 Sometimes logging is used for fast-feedback loops when prototyping application functionality, but eventually become redundant, or the application they provide does not provide additional operational or debugging value for an operator searching through logs.
 

--- a/docs/patterns/securing-application-logging.md
+++ b/docs/patterns/securing-application-logging.md
@@ -69,9 +69,9 @@ Logging full payloads should be avoided. However, logging full payloads can be u
 
 Examples of combined PII include:
 * Passport number, Issuing Country, Expiry Dates
-* BRP/C number, Date of Birth
+* Biometric residence permit or card (BRP/C) number, Date of Birth
   
-With the examples above, the information by themselves do not mean very much. After all, a BRP/C number is just a "random" sequence of characters; but in combination with the date of birth it can be used to uniquely identify an individual.
+With the examples above, the information by themselves do not mean very much. After all, a BRP/C number is a random sequence of characters; but in combination with the date of birth it can be used to uniquely identify an individual.
   
 If you are unsure what is person identifiable information, consult with your security specialists.
   

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -17,11 +17,9 @@ related:
           href: /patterns/securing-application-logging/ 
 ---
 
-Logging tools are one of the primary tools to debug application problems and identifying the root cause of incidents. However, logs need to be formatted in a standard way so that they are not only useful for the application's original developers, but also those supporting the application later in its life-cycle. 
+Logging tools are one of the primary tools to debug application problems and identifying the root cause of incidents. Logs need to be formatted in a standard way so that they are useful for the both application's developers and those supporting the application later in its life-cycle. 
 
-However, logs are sometimes relied on too heavily for problem detection, when this role would be better suited to purpose chosen monitoring tooling. 
-
-Therefore these standards provide guidance on both the proper format of application logs, as well as their proper usage.
+Logs are not a replacement for dedicated monitoring tooling. They should be used as part of a broader observabilty toolset. This standard provides guidance on a standard format for application logs, and suitable uses.
 
 ---
 

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -1,9 +1,9 @@
 ---
 layout: standard
 order: 1
-title: Logging for applications / systems / services with centralised logging tooling
+title: Logging for services with centralised logging aggregation
 date: 2024-01-05 # this should be the date that the content was most recently amended or formally reviewed
-id: SEGAS-00014 # Set unique ID for standard
+id: SEGAS-00015 # Set unique ID for standard
 # use `tags: []` for no tags
 # Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
 # Note: tags must use sentence case capitalisation
@@ -76,12 +76,13 @@ Use HTML URL encoding as in the 'Notes on links' above, to ensure that links to 
 
 <table><thead><tr><th>INFORMATION</th><th>DESCRIPTION</th></tr></thead><tbody><tr><td>Date / Time</td><td>Each log message must include date and time (millisecond accuracy) (UTC).</td></tr><tr><td>Service</td><td>Each log message must be attributed to an service (i.e. hostname).</td></tr><tr><td>Log level</td><td>Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)</td></tr><tr><td>Log message</td><td>Each log message must have a log message</td></tr></tbody></table>
 
+The time source for all service logs must be consistent so that messages can be viewed & sorted easily.
+
 ### Service logs must be forwarded to log aggregators
 
 Service logs must be forwarded to the supported log aggregation tooling for centralised and persistent storage, and ease of querying log information across distributed applications and services.
 
 ### Service logs must be rotated daily and no more than 100 MB of logs to be retained
-<!-- this is repeated in the Securing application logging pattern-->
 
 Where log files are persisted locally, log files must be rotated to prevent filling up local disk space. Furthermore, no more than 100 MB of logs are to be persisted should your service generate lots of logs.
 
@@ -89,63 +90,17 @@ Where log files are persisted locally, log files must be rotated to prevent fill
 
 Services can have a variety of logs, including application, error, and access logs; so it must be possible to identify the source of the log data in the log aggregation tooling.
 
-### Service log messages must be consistent per log source
-
-Log messages must follow a consistent log messaging format per log source (e.g. access / audit / application etc) to allow for easy processing and translation of logs into other formats.
-
-### Service log messages must have a consistent time source
-
-All applications / services / system logs must have a consistent time source so that log messages can be viewed / sorted.
-
-### Service log messages must not reveal any person identifiable information
-<!-- this is repeated in the Securing application logging pattern-->
-
-Information and data sets that can be used to directly identify a person should not output to logs regardless of log level.
-
-Examples of such information / data sets include,
-* Passport number, Issuing Country, Expiry Dates
-* BRP/C number, Date of Birth
-
-With the examples above, the information by themselves do not mean very much, after all a BRP/C number is just a "random" sequence of characters, but in combination with the date of birth it can be used to uniquely identify an individual.
-
-Such information should not be stored outside of the controls of the service that masters it due to regulatory controls (i.e. data persistence, retention, and security controls).
-
-If you are unsure what is person identifiable information, consult with your security specialists.
-
-### Service log messages must not reveal any sensitive information
-<!-- this is repeated in the Securing application logging pattern-->
-
-Information and data sets that contain sensitive information should not be output to logs regardless of log level.
-
-Such information should not be stored outside of the controls of the service that masters it due to regulatory controls (i.e. data persistence, retention, and security controls).
-
-If you are unsure what is sensitive information, consult with your security specialists.
-
 ### Service log messages should only be used for metrics, dashboarding and alerting as a last resort
 Although acceptable in some cases, it is strongly recommended that you do not use information contained in log messages as the primary method by which you report on application health, performance and business metrics. Information in logs can be difficult to parse, aggregate and quite brittle.
 
 The use of your approved tooling for service monitoring and alerting should always be prioritised over the use of log-based monitoring.
 
 ### There must be no DEBUG / TRACE level messages in Production environments
-<!-- this is repeated in the Securing application logging pattern-->
 
-Service log messages should not output DEBUG or TRACE level messages in PRODUCTION. The Default log level for production environments is INFO level.
+Refer to our [managing secrets]({{ '/patterns/securing-application-logging/' | url }}) pattern for more details.
 
-DEBUG / TRACE level messages, other than filling up logs, often reveal a lot of information and data that should not be output during standard execution. If it is required, then this is by exception and will require approval from the appropriate system / data owners.
+### Service log messages must not reveal any sensitive information or person identifiable information
 
-<!-- the following standards may need to be added to their own tracing standards-->
-### Any HTTP request can be traced from start to finish (within system boundaries) 
-
-In highly distributed applications / systems / services, particularly with microservice based architectures, it is useful to be able to see all the parts of a single transaction from start to finish, including calls to external systems and services. Being able to do so enables troubleshooting and debugging of complex issues and identifying performance bottlenecks.
-
-### The time any HTTP request spends on each individual action can be measured
-
-In highly distributed applications / systems / services, particularly with microservice based architectures, it is useful to be able to see the time spent on each part of a single transaction from start to finish, including calls to external systems and services. Being able to do so enables troubleshooting and debugging of complex issues and identifying performance bottlenecks.
-
-### Any HTTP request must return an appropriate HTTP response code
-
-A response to a request must include an appropriate HTTP response code, doing so will aide monitoring tools in determining genuine failure / threat scenarios as well as determining service health.
-
-<table><thead><tr><th>CODE</th><th>DESCRIPTION</th></tr></thead><tbody><tr><td>1xx</td><td>Informational response codes</td></tr><tr><td>2xx</td><td>Successful responses</td></tr><tr><td>3xx</td><td>Redirect responses</td></tr><tr><td>4xx</td><td>Client errors</td></tr><tr><td>5xx</td><td>Server errors</td></tr></tbody></table>
+Refer to our [managing secrets]({{ '/patterns/securing-application-logging/' | url }}) pattern for more details.
 
 ---

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -2,11 +2,8 @@
 layout: standard
 order: 1
 title: Logging for services with centralised logging aggregation
-date: 2024-01-05 # this should be the date that the content was most recently amended or formally reviewed
-id: SEGAS-00015 # Set unique ID for standard
-# use `tags: []` for no tags
-# Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
-# Note: tags must use sentence case capitalisation
+date: 2024-01-24
+id: SEGAS-00015 
 tags:
   - SRE
   - Monitoring
@@ -20,87 +17,57 @@ related:
           href: /patterns/securing-application-logging/ 
 ---
 
-<!-- Standard description -->
+Logging tools are one of the primary tools to debug application problems and identifying the root cause of incidents. However, logs need to be formatted in a standard way so that they are not only useful for the application's original developers, but also those supporting the application later in its life-cycle. 
 
-Logging tools are one of the primary ways of debugging application problems and identifying the root cause of incidents. However, logs need to be in a standard and useful format so that they are not only useful for the application's original developers, but also support engineers down the line. However, logs are sometimes relied on to heavily for problem detection, over purpose chosen monitoring tooling. Therefore these standards provide guidance on the proper utilsation of application logs, as well as their format.
+However, logs are sometimes relied on too heavily for problem detection, when this role would be better suited to purpose chosen monitoring tooling. 
 
-<!-- 
-
-# Notes on line breaks
-
-Please see https://x-govuk.github.io/govuk-eleventy-plugin/markdown/#line-breaks for notes on usage of line breaks.
-
-# Notes on using links
-
-Internal links need to follow this format:
-[link text to internal page]({{ '/standards/writing-a-standard/' | url }})
-Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
-
-Anchor tags, such as those used when listing the requirements at the top of the 'Requirements' section, should use HTML URL Encoding. This ensures links to headers with punctuation will work as expected. You can obtain the HTML URL Encodeded link by running the site locally, inspecting the appropriate <h3> element in the browser's developer tools and copying the value from the 'id' attribute.
-
-External links follow standard markdown formatting:
-[link text to external page](https://example.com)
--->
+Therefore these standards provide guidance on both the proper format of application logs, as well as their proper usage.
 
 ---
 
-## Requirement(s)
+## Requirements
 
-<!-- Populate list for each requirement (there can be more than 2) -->
+- [Service logs MUST have the minimum required field](#service-logs-must-have-the-minimum-required-fields)
+- [Service logs MUST be forwarded to log aggregators](#service-logs-must-be-forwarded-to-log-aggregators)
+- [Service logs MUST be rotated daily and no more than 100 MB of logs to be retained](#service-logs-must-be-rotated-daily-and-no-more-than-100-mb-of-logs-to-be-retained)
+- [Service logs MUST have an identifiable source in the log aggregator](#service-logs-must-have-an-identifiable-source-in-the-log-aggregator)
+- [Service log messages should only be used for metrics, dashboarding and alerting as a last resort](#service-log-messages-should-only-be-used-for-metrics%2C-dashboarding-and-alerting-as-a-last-resort)
+- [There MUST be no DEBUG / TRACE level messages in Production environments](#there-must-be-no-debug-%2F-trace-level-messages-in-production-environments)
+- [Service log messages MUST not reveal any sensitive information or person identifiable information](#service-log-messages-must-not-reveal-any-sensitive-information-or-person-identifiable-information)
 
-<!--
 
-# Notes on anchor links
+### Service logs MUST have the minimum required fields
 
-Use HTML URL encoding as in the 'Notes on links' above, to ensure that links to headers with punctuation works as expected. For example:
+Information | Description
+------------| -----------
+ Date / Time | Each log message must include date and time (millisecond accuracy) (UTC). The time source for all service logs must be consistent so that messages can be viewed & sorted easily.
+Service | Each log message must be attributed to an service (i.e. hostname).
+Log level | Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)
+Log Message | Each log message must have a log message. Log messages must follow a consistent log messaging format for all log types to allow for easy processing and translation of logs to other formats.
 
-[Product documentation MUST include build, release and deployment processes](#product-documentation-must-include-build%2C-release-and-deployment-processes)
-
--->
-
-- [Service logs must have the minimum required field](#service-logs-must-have-the-minimum-required-fields)
-- [Service logs must be forwarded to log aggregators](#service-logs-must-be-forwarded-to-log-aggregators)
-- [Service logs must be rotated daily and no more than 100 MB of logs to be retained](#service-logs-must-be-rotated-daily-and-no-more-than-100-mb-of-logs-to-be-retained) <!-- Some overlap -->
-- [ervice logs must have an identifiable source in the log aggregator](#service-logs-must-have-an-identifiable-source-in-the-log-aggregator)
-- [Service log messages must be consistent per log source](#service-log-messages-must-be-consistent-per-log-source)
-- [Service log messages must have a consistent time source](#service-log-messages-must-have-a-consistent-time-source)
-- [Service log messages must not reveal any person identifiable information](#service-log-messages-must-not-reveal-any-person-identifiable-information) <!-- overlap -->
-- [Service log messages must not reveal any sensitive information.](#service-log-messages-must-not-reveal-any-sensitive-information) <!-- overlap -->
-- [Service log messages should only be used for metrics, dashboarding and alerting as a last resort](#service-log-messages-should-only-be-used-for-metrics-dashboarding-and-alerting-as-a-last-resort)
-- [There must be no DEBUG / TRACE level debug messages in Production environments.](#there-must-be-no-debug--trace-level-debug-messages-in-production-environments) <!-- overlap -->
-- [Any HTTP request can be traced from start to finish (within system boundaries)](#any-http-request-can-be-traced-from-start-to-finish-within-system-boundaries)
-- [The time any HTTP request spends on each individual action can be measured](#the-time-any-http-request-spends-on-each-individual-action-can-be-measured)
-- [Any HTTP request must return an appropriate HTTP response code](#any-http-request-must-return-an-appropriate-http-response-code)
-
-### Service logs must have the minimum required fields
-
-<table><thead><tr><th>INFORMATION</th><th>DESCRIPTION</th></tr></thead><tbody><tr><td>Date / Time</td><td>Each log message must include date and time (millisecond accuracy) (UTC).</td></tr><tr><td>Service</td><td>Each log message must be attributed to an service (i.e. hostname).</td></tr><tr><td>Log level</td><td>Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)</td></tr><tr><td>Log message</td><td>Each log message must have a log message</td></tr></tbody></table>
-
-The time source for all service logs must be consistent so that messages can be viewed & sorted easily.
-
-### Service logs must be forwarded to log aggregators
+### Service logs MUST be forwarded to log aggregators
 
 Service logs must be forwarded to the supported log aggregation tooling for centralised and persistent storage, and ease of querying log information across distributed applications and services.
 
-### Service logs must be rotated daily and no more than 100 MB of logs to be retained
+### Service logs MUST be rotated daily and no more than 100 MB of logs to be retained
 
 Where log files are persisted locally, log files must be rotated to prevent filling up local disk space. Furthermore, no more than 100 MB of logs are to be persisted should your service generate lots of logs.
 
-### Service logs must have an identifiable source in the log aggregator
+### Service logs MUST have an identifiable source in the log aggregator
 
 Services can have a variety of logs, including application, error, and access logs; so it must be possible to identify the source of the log data in the log aggregation tooling.
 
 ### Service log messages should only be used for metrics, dashboarding and alerting as a last resort
 Although acceptable in some cases, it is strongly recommended that you do not use information contained in log messages as the primary method by which you report on application health, performance and business metrics. Information in logs can be difficult to parse, aggregate and quite brittle.
-
+  
 The use of your approved tooling for service monitoring and alerting should always be prioritised over the use of log-based monitoring.
 
-### There must be no DEBUG / TRACE level messages in Production environments
+### There MUST be no DEBUG / TRACE level messages in Production environments
 
-Refer to our [managing secrets]({{ '/patterns/securing-application-logging/' | url }}) pattern for more details.
+Refer to our [securing application logging]({{ '/patterns/securing-application-logging/#take-care-when-using-detailed-logging-to-support-application-debugging' | url }}) pattern for more details.
 
-### Service log messages must not reveal any sensitive information or person identifiable information
+### Service log messages MUST not reveal any sensitive information or person identifiable information
 
-Refer to our [managing secrets]({{ '/patterns/securing-application-logging/' | url }}) pattern for more details.
+Refer to our [securing application logging]({{ '/patterns/securing-application-logging/#consider-how-information-can-combine-to-form-pii' | url }}) pattern for more details.
 
 ---

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -1,0 +1,149 @@
+---
+layout: standard
+order: 1
+title: Logging for applications / systems / services with centralised logging tooling
+date: 2024-01-05 # this should be the date that the content was most recently amended or formally reviewed
+id: SEGAS-00014 # Set unique ID for standard
+# use `tags: []` for no tags
+# Check https://ho-cto.github.io/engineering-guidance-and-standards/tags/ for existing tags
+# Note: tags must use sentence case capitalisation
+tags:
+  - SRE
+  - Monitoring
+  - Observability
+  - Logging
+related: 
+  sections:
+    - title: Securing application logging
+      items:
+        - text: Securing application logging
+          href: /patterns/securing-application-logging/ 
+---
+
+<!-- Standard description -->
+
+to-do
+
+<!-- 
+
+# Notes on line breaks
+
+Please see https://x-govuk.github.io/govuk-eleventy-plugin/markdown/#line-breaks for notes on usage of line breaks.
+
+# Notes on using links
+
+Internal links need to follow this format:
+[link text to internal page]({{ '/standards/writing-a-standard/' | url }})
+Note the use of the `url` filter. This ensures the link is appended to the base URL of the webpage correctly.
+
+Anchor tags, such as those used when listing the requirements at the top of the 'Requirements' section, should use HTML URL Encoding. This ensures links to headers with punctuation will work as expected. You can obtain the HTML URL Encodeded link by running the site locally, inspecting the appropriate <h3> element in the browser's developer tools and copying the value from the 'id' attribute.
+
+External links follow standard markdown formatting:
+[link text to external page](https://example.com)
+-->
+
+---
+
+## Requirement(s)
+
+<!-- Populate list for each requirement (there can be more than 2) -->
+
+<!--
+
+# Notes on anchor links
+
+Use HTML URL encoding as in the 'Notes on links' above, to ensure that links to headers with punctuation works as expected. For example:
+
+[Product documentation MUST include build, release and deployment processes](#product-documentation-must-include-build%2C-release-and-deployment-processes)
+
+-->
+
+- [Application / service / system logs must have at least the following fields as a minimum](#Application--service--system-logs-must-have-at-least-the-following-fields-as-a-minimum)
+- [Application / service / system logs must be forwarded to the supported log aggregation tooling.](#application--service--system-logs-must-be-forwarded-to-the-supported-log-aggregation-tooling)
+- [Application / service / system logs must be rotated daily and no more than 100 MB of logs to be retained on the pods at any given time.](#application--service--system-logs-must-be-rotated-daily-and-no-more-than-100-mb-of-logs-to-be-retained-on-the-pods-at-any-given-time) <!-- Some overlap -->
+- [Application / service / system logs must have an identifiable source (e.g. access / audit / application etc.) in the log aggregation tooling.](#application--service--system-logs-must-have-an-identifiable-source-eg-access--audit--application-etc-in-the-log-aggregation-tooling)
+- [Application / service / system log messages must be consistent per log source (e.g. access / audit / application etc)](#application--service--system-log-messages-must-be-consistent-per-log-source-eg-access--audit--application-etc)
+- [Application / service / system log messages must have a consistent time source](#application--service--system-log-messages-must-have-a-consistent-time-source)
+- [Application / service / system log messages must not reveal any person identifiable information](#application--service--system-log-messages-must-not-reveal-any-person-identifiable-information) <!-- overlap -->
+- [Application / service / system log messages must not reveal any sensitive information.](#application--service--system-log-messages-must-not-reveal-any-sensitive-information) <!-- overlap -->
+- [Application / service / system log messages should only be used for metrics, dashboarding and alerting as a final option. All efforts should be made to migrate log-based monitoring towards purpose-built monitoring tooling](#application--service--system-log-messages-should-only-be-used-for-metrics-dashboarding-and-alerting-as-a-final-option-all-efforts-should-be-made-to-migrate-log-based-monitoring-towards-purpose-built-monitoring-tooling)
+- [Default log level for production environments is INFO level; there must be no DEBUG / TRACE level debug messages in Production environments.](#default-log-level-for-production-environments-is-info-level-there-must-be-no-debug--trace-level-debug-messages-in-production-environments) <!-- overlap -->
+- [Given a single [HTTP] request, you can trace its journey from start to finish (within system boundaries). This includes calls to and from upstream / downstream applications / services / systems and message queuing and database interactions.] (#given-a-single-http-request-you-can-trace-its-journey-from-start-to-finish-within-system-boundaries-this-includes-calls-to-and-from-upstream--downstream-applications--services--systems-and-message-queuing-and-database-interactions)
+- [Given a single [HTTP] request, you can trace its journey from start to finish measuring time spent on each individual action, including calls to external applications / services / systems.](#given-a-single-http-request-you-can-trace-its-journey-from-start-to-finish-measuring-time-spent-on-each-individual-action-including-calls-to-external-applications--services--systems)
+- [Given a single [HTTP] request, the request must return an appropriate HTTP response code in its logs.](#given-a-single-http-request-the-request-must-return-an-appropriate-http-response-code)
+
+
+### Application / service / system logs must have at least the following fields as a minimum
+
+<table><thead><tr><th>INFORMATION</th><th>DESCRIPTION</th></tr></thead><tbody><tr><td>Date / Time</td><td>Each log message must include date and time (millisecond accuracy) (UTC).</td></tr><tr><td>Application / Service / System</td><td>Each log message must be attributed to an application / service / system (i.e. hostname).</td></tr><tr><td>Log level</td><td>Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)</td></tr><tr><td>Log message</td><td>Each log message must have a log message</td></tr></tbody></table>
+
+### Application / service / system logs must be forwarded to the supported log aggregation tooling.
+
+Application / service / system logs must be forwarded to the supported log aggregation tooling for centralised and persistent storage, and ease of querying log information across distributed applications and services.
+
+### Application / service / system logs must be rotated daily and no more than 100 MB of logs to be retained on the pods at any given time.
+
+Where log files are persisted locally, log files must be rotated to prevent filling up local disk space. Furthermore, no more than 100 MB of logs are to be persisted should your application / service / system generate lots of logs.
+
+### Application / service / system logs must have an identifiable source (e.g. access / audit / application etc.) in the log aggregation tooling.
+
+Application / service / systems can have a variety of logs, including application, error, and access logs; so it must be possible to identify the source of the log data in the log aggregation tooling.
+
+### Application / service / system log messages must be consistent per log source (e.g. access / audit / application etc)
+
+Log messages must follow a consistent log messaging format per log source to allow for easy processing and translation of logs into other formats.
+
+### Application / service / system log messages must have a consistent time source
+
+All applications / services / system logs must have a consistent time source so that log messages can be viewed / sorted.
+
+### Application / service / system log messages must not reveal any person identifiable information
+
+Information and data sets that can be used to directly identify a person should not output to logs regardless of log level.
+
+Examples of such information / data sets include,
+* Passport number, Issuing Country, Expiry Dates
+* BRP/C number, Date of Birth
+
+With the examples above, the information by themselves do not mean very much, after all a BRP/C number is just a "random" sequence of characters, but in combination with the date of birth it can be used to uniquely identify an individual.
+
+Such information should not be stored outside of the controls of the application / service / system that masters it due to regulatory controls (i.e. data persistence, retention, and security controls).
+
+If you are unsure what is person identifiable information, consult with your security specialists.
+
+
+### Application / service / system log messages must not reveal any sensitive information.
+
+Information and data sets that contain sensitive information should not be output to logs regardless of log level.
+
+Such information should not be stored outside of the controls of the application / service / system that masters it due to regulatory controls (i.e. data persistence, retention, and security controls).
+
+If you are unsure what is sensitive information, consult with your security specialists.
+
+### Application / service / system log messages should only be used for metrics, dashboarding and alerting as a final option. All efforts should be made to migrate log-based monitoring towards purpose-built monitoring tooling
+
+Although acceptable in some cases, it is strongly recommended that you do not use information contained in log messages as the primary method by which you report on application health, performance and business metrics. Information in logs can be difficult to parse, aggregate and quite brittle.
+
+The use of your approved tooling for application / service / system monitoring and alerting should always be prioritised over the use of log-based monitoring.
+
+### Default log level for production environments is INFO level; there must be no DEBUG / TRACE level debug messages in Production environments.
+
+Application / service / system log messages should not output DEBUG or TRACE level messages in PRODUCTION.
+
+DEBUG / TRACE level messages, other than filling up logs, often reveal a lot of information and data that should not be output during standard execution. If it is required, then this is by exception and will require approval from the appropriate system / data owners.
+
+### Given a single [HTTP] request, you can trace its journey from start to finish (within system boundaries). This includes calls to and from upstream / downstream applications / services / systems and message queuing and database interactions.
+
+In highly distributed applications / systems / services, particularly with microservice based architectures, it is useful to be able to see all the parts of a single transaction from start to finish, including calls to external systems and services. Being able to do so enables troubleshooting and debugging of complex issues and identifying performance bottlenecks.
+
+### Given a single [HTTP] request, you can trace its journey from start to finish measuring time spent on each individual action, including calls to external applications / services / systems.
+
+In highly distributed applications / systems / services, particularly with microservice based architectures, it is useful to be able to see the time spent on each part of a single transaction from start to finish, including calls to external systems and services. Being able to do so enables troubleshooting and debugging of complex issues and identifying performance bottlenecks.
+
+### Given a single [HTTP] request, the request must return an appropriate HTTP response code.
+
+A response to a request must include an appropriate HTTP response code, doing so will aide monitoring tools in determining genuine failure / threat scenarios as well as determining application / service / system health.
+
+<table><thead><tr><th>CODE</th><th>DESCRIPTION</th></tr></thead><tbody><tr><td>1xx</td><td>Informational response codes</td></tr><tr><td>2xx</td><td>Successful responses</td></tr><tr><td>3xx</td><td>Redirect responses</td></tr><tr><td>4xx</td><td>Client errors</td></tr><tr><td>5xx</td><td>Server errors</td></tr></tbody></table>
+
+---

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -22,7 +22,7 @@ related:
 
 <!-- Standard description -->
 
-to-do
+Logging tools are one of the primary ways of debugging application problems and identifying the root cause of incidents. However, logs need to be in a standard and useful format so that they are not only useful for the application's original developers, but also support engineers down the line. However, logs are sometimes relied on to heavily for problem detection, over purpose chosen monitoring tooling. Therefore these standards provide guidance on the proper utilsation of application logs, as well as their format.
 
 <!-- 
 

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -58,46 +58,47 @@ Use HTML URL encoding as in the 'Notes on links' above, to ensure that links to 
 
 -->
 
-- [Application / service / system logs must have at least the following fields as a minimum](#Application--service--system-logs-must-have-at-least-the-following-fields-as-a-minimum)
-- [Application / service / system logs must be forwarded to the supported log aggregation tooling.](#application--service--system-logs-must-be-forwarded-to-the-supported-log-aggregation-tooling)
-- [Application / service / system logs must be rotated daily and no more than 100 MB of logs to be retained on the pods at any given time.](#application--service--system-logs-must-be-rotated-daily-and-no-more-than-100-mb-of-logs-to-be-retained-on-the-pods-at-any-given-time) <!-- Some overlap -->
-- [Application / service / system logs must have an identifiable source (e.g. access / audit / application etc.) in the log aggregation tooling.](#application--service--system-logs-must-have-an-identifiable-source-eg-access--audit--application-etc-in-the-log-aggregation-tooling)
-- [Application / service / system log messages must be consistent per log source (e.g. access / audit / application etc)](#application--service--system-log-messages-must-be-consistent-per-log-source-eg-access--audit--application-etc)
-- [Application / service / system log messages must have a consistent time source](#application--service--system-log-messages-must-have-a-consistent-time-source)
-- [Application / service / system log messages must not reveal any person identifiable information](#application--service--system-log-messages-must-not-reveal-any-person-identifiable-information) <!-- overlap -->
-- [Application / service / system log messages must not reveal any sensitive information.](#application--service--system-log-messages-must-not-reveal-any-sensitive-information) <!-- overlap -->
-- [Application / service / system log messages should only be used for metrics, dashboarding and alerting as a final option. All efforts should be made to migrate log-based monitoring towards purpose-built monitoring tooling](#application--service--system-log-messages-should-only-be-used-for-metrics-dashboarding-and-alerting-as-a-final-option-all-efforts-should-be-made-to-migrate-log-based-monitoring-towards-purpose-built-monitoring-tooling)
-- [Default log level for production environments is INFO level; there must be no DEBUG / TRACE level debug messages in Production environments.](#default-log-level-for-production-environments-is-info-level-there-must-be-no-debug--trace-level-debug-messages-in-production-environments) <!-- overlap -->
-- [Given a single [HTTP] request, you can trace its journey from start to finish (within system boundaries). This includes calls to and from upstream / downstream applications / services / systems and message queuing and database interactions.] (#given-a-single-http-request-you-can-trace-its-journey-from-start-to-finish-within-system-boundaries-this-includes-calls-to-and-from-upstream--downstream-applications--services--systems-and-message-queuing-and-database-interactions)
-- [Given a single [HTTP] request, you can trace its journey from start to finish measuring time spent on each individual action, including calls to external applications / services / systems.](#given-a-single-http-request-you-can-trace-its-journey-from-start-to-finish-measuring-time-spent-on-each-individual-action-including-calls-to-external-applications--services--systems)
-- [Given a single [HTTP] request, the request must return an appropriate HTTP response code in its logs.](#given-a-single-http-request-the-request-must-return-an-appropriate-http-response-code)
+- [Service logs must have the minimum required field](#service-logs-must-have-the-minimum-required-fields)
+- [Service logs must be forwarded to log aggregators](#service-logs-must-be-forwarded-to-log-aggregators)
+- [Service logs must be rotated daily and no more than 100 MB of logs to be retained](#service-logs-must-be-rotated-daily-and-no-more-than-100-mb-of-logs-to-be-retained) <!-- Some overlap -->
+- [ervice logs must have an identifiable source in the log aggregator](#service-logs-must-have-an-identifiable-source-in-the-log-aggregator)
+- [Service log messages must be consistent per log source](#service-log-messages-must-be-consistent-per-log-source)
+- [Service log messages must have a consistent time source](#service-log-messages-must-have-a-consistent-time-source)
+- [Service log messages must not reveal any person identifiable information](#service-log-messages-must-not-reveal-any-person-identifiable-information) <!-- overlap -->
+- [Service log messages must not reveal any sensitive information.](#service-log-messages-must-not-reveal-any-sensitive-information) <!-- overlap -->
+- [Service log messages should only be used for metrics, dashboarding and alerting as a last resort](#service-log-messages-should-only-be-used-for-metrics-dashboarding-and-alerting-as-a-last-resort)
+- [There must be no DEBUG / TRACE level debug messages in Production environments.](#there-must-be-no-debug--trace-level-debug-messages-in-production-environments) <!-- overlap -->
+- [Any HTTP request can be traced from start to finish (within system boundaries)](#any-http-request-can-be-traced-from-start-to-finish-within-system-boundaries)
+- [The time any HTTP request spends on each individual action can be measured](#the-time-any-http-request-spends-on-each-individual-action-can-be-measured)
+- [Any HTTP request must return an appropriate HTTP response code](#any-http-request-must-return-an-appropriate-http-response-code)
 
+### Service logs must have the minimum required fields
 
-### Application / service / system logs must have at least the following fields as a minimum
+<table><thead><tr><th>INFORMATION</th><th>DESCRIPTION</th></tr></thead><tbody><tr><td>Date / Time</td><td>Each log message must include date and time (millisecond accuracy) (UTC).</td></tr><tr><td>Service</td><td>Each log message must be attributed to an service (i.e. hostname).</td></tr><tr><td>Log level</td><td>Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)</td></tr><tr><td>Log message</td><td>Each log message must have a log message</td></tr></tbody></table>
 
-<table><thead><tr><th>INFORMATION</th><th>DESCRIPTION</th></tr></thead><tbody><tr><td>Date / Time</td><td>Each log message must include date and time (millisecond accuracy) (UTC).</td></tr><tr><td>Application / Service / System</td><td>Each log message must be attributed to an application / service / system (i.e. hostname).</td></tr><tr><td>Log level</td><td>Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)</td></tr><tr><td>Log message</td><td>Each log message must have a log message</td></tr></tbody></table>
+### Service logs must be forwarded to log aggregators
 
-### Application / service / system logs must be forwarded to the supported log aggregation tooling.
+Service logs must be forwarded to the supported log aggregation tooling for centralised and persistent storage, and ease of querying log information across distributed applications and services.
 
-Application / service / system logs must be forwarded to the supported log aggregation tooling for centralised and persistent storage, and ease of querying log information across distributed applications and services.
+### Service logs must be rotated daily and no more than 100 MB of logs to be retained
+<!-- this is repeated in the Securing application logging pattern-->
 
-### Application / service / system logs must be rotated daily and no more than 100 MB of logs to be retained on the pods at any given time.
+Where log files are persisted locally, log files must be rotated to prevent filling up local disk space. Furthermore, no more than 100 MB of logs are to be persisted should your service generate lots of logs.
 
-Where log files are persisted locally, log files must be rotated to prevent filling up local disk space. Furthermore, no more than 100 MB of logs are to be persisted should your application / service / system generate lots of logs.
+### Service logs must have an identifiable source in the log aggregator
 
-### Application / service / system logs must have an identifiable source (e.g. access / audit / application etc.) in the log aggregation tooling.
+Services can have a variety of logs, including application, error, and access logs; so it must be possible to identify the source of the log data in the log aggregation tooling.
 
-Application / service / systems can have a variety of logs, including application, error, and access logs; so it must be possible to identify the source of the log data in the log aggregation tooling.
+### Service log messages must be consistent per log source
 
-### Application / service / system log messages must be consistent per log source (e.g. access / audit / application etc)
+Log messages must follow a consistent log messaging format per log source (e.g. access / audit / application etc) to allow for easy processing and translation of logs into other formats.
 
-Log messages must follow a consistent log messaging format per log source to allow for easy processing and translation of logs into other formats.
-
-### Application / service / system log messages must have a consistent time source
+### Service log messages must have a consistent time source
 
 All applications / services / system logs must have a consistent time source so that log messages can be viewed / sorted.
 
-### Application / service / system log messages must not reveal any person identifiable information
+### Service log messages must not reveal any person identifiable information
+<!-- this is repeated in the Securing application logging pattern-->
 
 Information and data sets that can be used to directly identify a person should not output to logs regardless of log level.
 
@@ -107,42 +108,43 @@ Examples of such information / data sets include,
 
 With the examples above, the information by themselves do not mean very much, after all a BRP/C number is just a "random" sequence of characters, but in combination with the date of birth it can be used to uniquely identify an individual.
 
-Such information should not be stored outside of the controls of the application / service / system that masters it due to regulatory controls (i.e. data persistence, retention, and security controls).
+Such information should not be stored outside of the controls of the service that masters it due to regulatory controls (i.e. data persistence, retention, and security controls).
 
 If you are unsure what is person identifiable information, consult with your security specialists.
 
-
-### Application / service / system log messages must not reveal any sensitive information.
+### Service log messages must not reveal any sensitive information
+<!-- this is repeated in the Securing application logging pattern-->
 
 Information and data sets that contain sensitive information should not be output to logs regardless of log level.
 
-Such information should not be stored outside of the controls of the application / service / system that masters it due to regulatory controls (i.e. data persistence, retention, and security controls).
+Such information should not be stored outside of the controls of the service that masters it due to regulatory controls (i.e. data persistence, retention, and security controls).
 
 If you are unsure what is sensitive information, consult with your security specialists.
 
-### Application / service / system log messages should only be used for metrics, dashboarding and alerting as a final option. All efforts should be made to migrate log-based monitoring towards purpose-built monitoring tooling
-
+### Service log messages should only be used for metrics, dashboarding and alerting as a last resort
 Although acceptable in some cases, it is strongly recommended that you do not use information contained in log messages as the primary method by which you report on application health, performance and business metrics. Information in logs can be difficult to parse, aggregate and quite brittle.
 
-The use of your approved tooling for application / service / system monitoring and alerting should always be prioritised over the use of log-based monitoring.
+The use of your approved tooling for service monitoring and alerting should always be prioritised over the use of log-based monitoring.
 
-### Default log level for production environments is INFO level; there must be no DEBUG / TRACE level debug messages in Production environments.
+### There must be no DEBUG / TRACE level messages in Production environments
+<!-- this is repeated in the Securing application logging pattern-->
 
-Application / service / system log messages should not output DEBUG or TRACE level messages in PRODUCTION.
+Service log messages should not output DEBUG or TRACE level messages in PRODUCTION. The Default log level for production environments is INFO level.
 
 DEBUG / TRACE level messages, other than filling up logs, often reveal a lot of information and data that should not be output during standard execution. If it is required, then this is by exception and will require approval from the appropriate system / data owners.
 
-### Given a single [HTTP] request, you can trace its journey from start to finish (within system boundaries). This includes calls to and from upstream / downstream applications / services / systems and message queuing and database interactions.
+<!-- the following standards may need to be added to their own tracing standards-->
+### Any HTTP request can be traced from start to finish (within system boundaries) 
 
 In highly distributed applications / systems / services, particularly with microservice based architectures, it is useful to be able to see all the parts of a single transaction from start to finish, including calls to external systems and services. Being able to do so enables troubleshooting and debugging of complex issues and identifying performance bottlenecks.
 
-### Given a single [HTTP] request, you can trace its journey from start to finish measuring time spent on each individual action, including calls to external applications / services / systems.
+### The time any HTTP request spends on each individual action can be measured
 
 In highly distributed applications / systems / services, particularly with microservice based architectures, it is useful to be able to see the time spent on each part of a single transaction from start to finish, including calls to external systems and services. Being able to do so enables troubleshooting and debugging of complex issues and identifying performance bottlenecks.
 
-### Given a single [HTTP] request, the request must return an appropriate HTTP response code.
+### Any HTTP request must return an appropriate HTTP response code
 
-A response to a request must include an appropriate HTTP response code, doing so will aide monitoring tools in determining genuine failure / threat scenarios as well as determining application / service / system health.
+A response to a request must include an appropriate HTTP response code, doing so will aide monitoring tools in determining genuine failure / threat scenarios as well as determining service health.
 
 <table><thead><tr><th>CODE</th><th>DESCRIPTION</th></tr></thead><tbody><tr><td>1xx</td><td>Informational response codes</td></tr><tr><td>2xx</td><td>Successful responses</td></tr><tr><td>3xx</td><td>Redirect responses</td></tr><tr><td>4xx</td><td>Client errors</td></tr><tr><td>5xx</td><td>Server errors</td></tr></tbody></table>
 


### PR DESCRIPTION
A PR to create a new set of Standards for application logging, based on those that exist in MBTP already.

# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
