### PR TITLE
Add Generative AI link to the link checking exemption

### DIFF
--- a/cypress/support/link-exception-list.json
+++ b/cypress/support/link-exception-list.json
@@ -2,5 +2,6 @@
   "https://www.homeofficesurveys.homeoffice.gov.uk/s/8PDDG2/",
   "https://opensource.org/licenses/",
   "https://opensource.org/license/mit/",
-  "https://www.splunk.com/en_us/blog/learn/observability.html?301=/en_us/data-insider/what-is-observability.html"
+  "https://www.splunk.com/en_us/blog/learn/observability.html?301=/en_us/data-insider/what-is-observability.html",
+  "https://www.gartner.com/en/topics/generative-ai"
 ]


### PR DESCRIPTION
# Code change

Add https://www.gartner.com/en/topics/generative-ai to the link checking exemption list to prevent flaky tests

I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).
- [X] This change will not change layouts, page structures or anything else that might impact accessibility