### PR TITLE
#364 - Review SEGAS-00003 Minimal documentation set for a product

### DIFF
--- a/docs/standards/minimal-documentation-set-for-a-product.md
+++ b/docs/standards/minimal-documentation-set-for-a-product.md
@@ -18,7 +18,7 @@ A product should be documented to a minimum standard so that new engineers can b
 - [Product documentation MUST include a description of the product and what it is for](#product-documentation-must-include-a-description-of-the-product-and-what-it-is-for)
 - [Product documentation MUST include key architectural views](#product-documentation-must-include-key-architectural-views)
 - [Product documentation MUST include a decision log](#product-documentation-must-include-a-decision-log)
-- [Product documentation MUST include incident management information](#product-documentation-must-include-incident-management-information)
+- [Product documentation MUST include runbooks for expected tasks](#product-documentation-must-include-runbooks-for-expected-tasks)
 - [Product documentation MUST include information about observability](#product-documentation-must-include-information-about-observability)
 - [Product documentation MUST include build, release and deployment processes](#product-documentation-must-include-build%2C-release-and-deployment-processes)
 
@@ -28,6 +28,7 @@ The description should provide domain context to an engineer and link to product
 
 - Information about the team
 - Key stakeholders
+    - Include contacts in case of a technical incident with the product
 - Who the [Senior Responsible Owner (SRO)](https://www.gov.uk/government/publications/the-role-of-the-senior-responsible-owner/the-role-of-the-senior-responsible-owner) is
 - User research findings
 - Product roadmap
@@ -35,7 +36,7 @@ The description should provide domain context to an engineer and link to product
 - Governance and assurance documentation
     - IT health check reports
     - Security audits
-    - Service design package
+    - Service design package which MUST include the incident management process
 
 ### Product documentation MUST include key architectural views
 
@@ -45,9 +46,11 @@ The architectural views may contain architecture diagrams, security models, enti
 
 A decision log should record key design decisions in context. A pattern should be selected to complement the team ways of working, and may include for example [Architecture Decision Records](https://adr.github.io/). 
 
-### Product documentation MUST include incident management information
+### Product documentation MUST include runbooks for expected tasks
 
-An incident management process should include technical points of contact, runbooks, and disaster recovery information.
+Document any incident support and maintenance tasks that are the responsibility of the product team. 
+
+Where a task can't be automated, provide a runbook detailing how to carry out that task.
 
 ### Product documentation MUST include information about observability
 

--- a/docs/standards/minimal-documentation-set-for-a-product.md
+++ b/docs/standards/minimal-documentation-set-for-a-product.md
@@ -48,7 +48,7 @@ A decision log should record key design decisions in context. A pattern should b
 
 ### Product documentation MUST include runbooks for expected tasks
 
-Document any incident support and maintenance tasks that are the responsibility of the product team. 
+Document any incident support, disaster recovery, and maintenance tasks that are the responsibility of the product team. 
 
 Where a task can't be automated, provide a runbook detailing how to carry out that task.
 

--- a/docs/standards/minimal-documentation-set-for-a-product.md
+++ b/docs/standards/minimal-documentation-set-for-a-product.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Minimal documentation set for a product
-date: 2024-03-07
+date: 2024-03-14
 id: SEGAS-00003
 tags:
 - Documentation

--- a/docs/standards/minimal-documentation-set-for-a-product.md
+++ b/docs/standards/minimal-documentation-set-for-a-product.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Minimal documentation set for a product
-date: 2023-10-26
+date: 2024-03-07
 id: SEGAS-00003
 tags:
 - Documentation


### PR DESCRIPTION
After discussion in the ways of working guild meeting on 7th March 2024 we agreed that a lot of the incident management information is included in the product description section. This is now called out in that section, and the incident management has been rewritten to be about runbooks for expected tasks.

# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
