### PR TITLE
Remove trailing `]` from about page security link

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -4,7 +4,7 @@ layout: post
 order: 5
 title: About
 description: Find out more about what we are doing
-tags:
+tags: []
 ---
 
 The Home Office Engineering Guidance and Standards site is a body of knowledge for software engineers. It is comprised of principles, patterns and standards that define how we do engineering at the Home Office, and that direct how we want to do engineering in the future. This guidance is created and curated by the Home Office engineering community. The project as a whole is led by the Home Office DDaT Engineering Profession team.
@@ -47,7 +47,7 @@ Security
 
   [**Slack**: #segas-security](https://homeoffice.enterprise.slack.com/archives/C0282A158FM)
 
-  [Pages tagged with security](/tags/security/)]
+  [Pages tagged with security](/tags/security/)
 
 Software Design
 : Items to be covered to include Frameworks, Languages, Quality and Coding Standards.


### PR DESCRIPTION
# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- ~[X] Last updated date for content is correct~ N/A - change to a site page, not a pattern, standard, or principle.
