### PR TITLE
Re-apply typo fix from #442 on latest main with signed commit

### DIFF
--- a/docs/patterns/write-effective-documentation.md
+++ b/docs/patterns/write-effective-documentation.md
@@ -64,7 +64,7 @@ Avoid making assumptions about your audience's knowledge. Different users need d
 
 ### Make your content accessible and inclusive
 
-Accessibility is the law. You should  [familiarise yourself with the WCAG principles](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag) and the [Home Office Accesibility Standard](https://design.homeoffice.gov.uk/accessibility/standard).
+Accessibility is the law. You should  [familiarise yourself with the WCAG principles](https://www.gov.uk/service-manual/helping-people-to-use-your-service/understanding-wcag) and the [Home Office Accessibility Standard](https://design.homeoffice.gov.uk/accessibility/standard).
 
 #### Write with a digital audience in mind
 

--- a/docs/patterns/write-effective-documentation.md
+++ b/docs/patterns/write-effective-documentation.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Write effective documentation
-date: 2023-07-18
+date: 2024-11-06
 tags:
 - Ways of working
 - Documentation


### PR DESCRIPTION
# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
