### PR TITLE
Make filename requirements explicit in writing-a-x standards

### DIFF
--- a/docs/standards/writing-a-principle.md
+++ b/docs/standards/writing-a-principle.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Writing a principle
-date: 2023-08-04
+date: 2024-11-28
 id: SEGAS-00002
 tags: []
 ---
@@ -31,10 +31,12 @@ State the essence of the principle and make it easy to remember. Avoid ambiguous
 ```yaml
 layout: principle
 order: 1
-title: Example software engineering principle
+title: Writing a principle
 tags:
   - Example
 ```
+
+The filename must be the kebab-cased title so that the principle's url matches. E.g. `writing-a-principle.md`.
 
 ### A principle MUST have a description
 

--- a/docs/standards/writing-a-principle.md
+++ b/docs/standards/writing-a-principle.md
@@ -36,7 +36,7 @@ tags:
   - Example
 ```
 
-The filename must be the kebab-cased title so that the principle's url matches. E.g. `writing-a-principle.md`.
+The filename must be the kebab-cased title so that the principle's url matches its title. E.g. `writing-a-principle.md`.
 
 ### A principle MUST have a description
 

--- a/docs/standards/writing-a-standard.md
+++ b/docs/standards/writing-a-standard.md
@@ -32,7 +32,7 @@ An unambiguous and unique identifier is needed for each standard. This provides 
 layout: standard
 order: 1
 title: Writing a standard
-date: 2024-03-18
+date: 2024-11-28
 id: SEGAS-00001
 tags:
   - Example
@@ -45,6 +45,8 @@ A short meaningful name is helpful to reference in conversation. Don't include w
 ```yaml
 title: Writing a standard
 ```
+
+The filename must be the kebab-cased title so that the standard's url matches. E.g. `writing-a-standard.md`.  
 
 ### A standard MUST have a description
 

--- a/docs/standards/writing-a-standard.md
+++ b/docs/standards/writing-a-standard.md
@@ -46,7 +46,7 @@ A short meaningful name is helpful to reference in conversation. Don't include w
 title: Writing a standard
 ```
 
-The filename must be the kebab-cased title so that the standard's url matches. E.g. `writing-a-standard.md`.  
+The filename must be the kebab-cased title so that the standard's url matches its title. E.g. `writing-a-standard.md`.  
 
 ### A standard MUST have a description
 


### PR DESCRIPTION
# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
