### PR TITLE
Build/test with latest node/ubuntu lts (v22)

### DIFF
--- a/.github/workflows/deploy-to-core-cloud.yml
+++ b/.github/workflows/deploy-to-core-cloud.yml
@@ -23,7 +23,7 @@ jobs:
     name: Build, test, and sync to S3
     environment:
       name: core-cloud
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       - name: Setup NPM cache
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Build site, run Cypress tests

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   e2e-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: cypress/browsers:node-20.5.0-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
     steps:
       - name: Checkout
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - name: Run Cypress Tests
         uses: cypress-io/github-action@v6

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "cypress:run": "cypress run",
     "docker:build": "docker build -t engineering-guidance-and-standards ."
   },
+  "engines": {
+    "node": ">=22.0.0 <23.0.0"
+  },
   "dependencies": {
     "@11ty/eleventy": "^3.0.0",
     "@x-govuk/govuk-eleventy-plugin": "^6.7.2",


### PR DESCRIPTION
Node is only used in the build process in the core cloud deployment. This updates the GitHub action runner and node version to the latest LTS versions.

# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).
- [X] This change will not change layouts, page structures or anything else that might impact accessibility
