### PR TITLE
Add SITE_ROOT env variable to core cloud build.

### DIFF
--- a/.github/workflows/deploy-to-core-cloud.yml
+++ b/.github/workflows/deploy-to-core-cloud.yml
@@ -56,6 +56,7 @@ jobs:
           CYPRESS_TEST_URL: ${{ env.CYPRESS_TEST_URL }}
           CYPRESS_TEST_PORT: ${{ env.CYPRESS_TEST_PORT }}
           GITHUB_COMMIT_SHA: ${{ github.event.push.after }}
+          SITE_ROOT: https://engineering.homeoffice.gov.uk/
 
       - name: Sync site to S3 bucket
         working-directory: ./_site


### PR DESCRIPTION
The site root is [populated from an environment variable](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/.eleventy.js#L26). When hosting on ACP this was [set in the Dockerfile](https://github.com/UKHomeOffice/engineering-guidance-and-standards/commit/f9d2390c9865a0ca38336e4ae1f17cae583bb7e2#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L10). This PR adds that environment variable to the GitHub action step that builds the production site.

Fixes #513.

# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [X] This change will not change layouts, page structures or anything else that might impact accessibility
