### PR TITLE
Add commit signing reminders to CONTRIBUTING.md and PULL_REQUEST_TEMPLATE

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ or
 
 ## Commit signing
 
-- [ ] All commits are signed. [GitHub guidance on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+- [ ] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
 
 # Content change 
 - [ ] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).
@@ -30,4 +30,4 @@ e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writi
     - Content does not refer to anti-fraud mechanisms
     - Content does not include sensitive business logic
 - [ ] Last updated date for content is correct
-- [ ] All commits are signed. [GitHub guidance on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+- [ ] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,6 +14,10 @@ or
 - [ ] This change might impact accessibility and is not covered by automated aXe tests - manual testing has been performed
 (If the change might impact accessibility then please add some further information here)
 
+## Commit signing
+
+- [ ] All commits are signed. [GitHub guidance on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification)
+
 # Content change 
 - [ ] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).
 
@@ -26,3 +30,4 @@ e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writi
     - Content does not refer to anti-fraud mechanisms
     - Content does not include sensitive business logic
 - [ ] Last updated date for content is correct
+- [ ] All commits are signed. [GitHub guidance on signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,7 @@ Make sure you pull your fork and switch to your new branch to do these changes.
 
 ### Commit your update
 
-Don't forget to commit and push your changes to your forked repo ready for the contribution!
+Don't forget to commit and push your changes to your forked repo ready for the contribution! Please make sure you have setup Git to sign your commits with a method that GitHub can verify. GitHub provides [instructions on setting up commit signing](https://docs.github.com/en/authentication/managing-commit-signature-verification). The repository rules require a fully signed commit history when merging a pull request into the main branch, so you will not be able to merge the resulting PR if any commits are unsigned.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,14 @@ Make sure you pull your fork and switch to your new branch to do these changes.
 
 ### Commit your update
 
-Don't forget to commit and push your changes to your forked repo ready for the contribution! Please make sure you have setup Git to sign your commits with a method that GitHub can verify. GitHub provides [instructions on setting up commit signing](https://docs.github.com/en/authentication/managing-commit-signature-verification). The repository rules require a fully signed commit history when merging a pull request into the main branch, so you will not be able to merge the resulting PR if any commits are unsigned.
+Don't forget to commit and push your changes to your forked repo ready for the contribution!
+
+Please make sure you have set up Git to sign your commits with a method that GitHub can verify. GitHub provides [instructions on setting up commit signing](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits). To help the site comply with [SEGAS-00009 - Signing code commits](https://engineering.homeoffice.gov.uk/standards/signing-code-commits/), the repository rules require a fully signed commit history when merging a pull request into the main branch. You will not be able to merge the resulting PR if any commits in the associated branch are unsigned, or if the signatures can't be verified by GitHub. If you are signing commits, and they are showing as unverified in GitHub, check you have added the relevant key to your account. When adding SSH keys in GitHub you can add the key as an authorisation key or a signing key. If you want to use the same key for both, you will need to add it twice, once for each purpose.
+
+If you have already pushed a commit that is unsigned, you can rectify this in two ways:
+
+1. Once commit signing is set up, rebase your work onto the main branch, then force push the changes. As with any force push, if you think others may have your branch checked out please make sure they are aware, e.g. with a comment on the pull request, so that they can update their local branches. This is usually not an issue for SEGAS contributions, as other collaborators work through the GitHub web interface rather than locally checked out versions.
+2. Create a new branch from the main branch, re-apply your changes to that branch, submit a new PR, and close the old one. This is usually more work, but can be simpler to manage if there are multiple contributors, or a complex commit history.
 
 ## Pull Requests
 


### PR DESCRIPTION
Commit signing is frequently missed by new contributors. We need to make it clear in guidance for contributions that commit signing is required.

Is this pull request a content or a code change? (Please fill in the relevant section and delete the other)

# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- ~Last updated date for content is correct~ GitHub, not site content. 
