### PR TITLE
Changed 'Last updated date' to explicit date of content update of 'End to end product ownership' principle

### DIFF
--- a/docs/principles/end-to-end-product-ownership.md
+++ b/docs/principles/end-to-end-product-ownership.md
@@ -2,7 +2,7 @@
 layout: principle
 order: 1
 title: End to end product ownership
-date: git Last Modified
+date: 2023-08-25
 tags:
 - Ways of working
 ---


### PR DESCRIPTION
Fixes #518 

[Bug] "End to end product ownership" principle has an incorrect Last updated date

Date 2023-08-25 used as per [last content change commit](https://github.com/UKHomeOffice/engineering-guidance-and-standards/commit/8a130bf637208d044311fc388e199af9ddac347a) brought by PR **Change service to product in "end to end product ownership" principle**  (https://github.com/UKHomeOffice/engineering-guidance-and-standards/pull/23(https://github.com/UKHomeOffice/engineering-guidance-and-standards/pull/234))
# Code change
I can confirm:
## Accessibility considerations
- [x] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [x] This change will not change layouts, page structures or anything else that might impact accessibility
