### PR TITLE
Link to Home Office docs-as-code template from docs-as-code pattern

### DIFF
--- a/docs/patterns/docs-as-code.md
+++ b/docs/patterns/docs-as-code.md
@@ -78,7 +78,7 @@ Comments
   
   A newer offering that also provides gov.uk styling and easy to configure search functionality.
 
-  The [Home Office docs-as-code template](https://github.com/UKHomeOffice/eleventy-docs-as-code-template) is a good starting point for a site with Home Office branding.
+  The [Home Office docs-as-code template](https://github.com/UKHomeOffice/eleventy-docs-as-code-template) is a good starting point for a site with Home Office branding. It replicates the base configuration and additional styles applied to this engineering guidance and standards site, resulting in a similar look and feel.
 
 Example of Home Office documentation using this option
 : - [DECS developer documentation](https://ukhomeoffice.github.io/hocs/get-started/)

--- a/docs/patterns/docs-as-code.md
+++ b/docs/patterns/docs-as-code.md
@@ -62,7 +62,7 @@ Comments
   The original GDS sponsored effort to create a gov.uk compliant docs as code pattern.
 
 Example of Home Office documentation using this option
-: [SRE monitoring as code](https://ho-cto.github.io/sre-monitoring-as-code/)
+: - [SRE monitoring as code](https://ho-cto.github.io/sre-monitoring-as-code/)
 
 #### Eleventy and x-gov Eleventy plugin
 
@@ -78,7 +78,10 @@ Comments
   
   A newer offering that also provides gov.uk styling and easy to configure search functionality.
 
+  The [Home Office docs-as-code template](https://github.com/UKHomeOffice/eleventy-docs-as-code-template) is a good starting point for a site with Home Office branding.
+
 Example of Home Office documentation using this option
-: [DECS developer documentation](https://ukhomeoffice.github.io/hocs/get-started/)
+: - [DECS developer documentation](https://ukhomeoffice.github.io/hocs/get-started/)
+  - [Developer healthcheck docs](https://ukhomeoffice.github.io/developer-healthcheck-docs/)
 
 ---

--- a/docs/patterns/docs-as-code.md
+++ b/docs/patterns/docs-as-code.md
@@ -2,7 +2,7 @@
 layout: pattern
 order: 1
 title: Docs as code
-date: 2023-08-11
+date: 2025-04-25
 tags:
 - Ways of working
 - Source management

--- a/docs/patterns/docs-as-code.md
+++ b/docs/patterns/docs-as-code.md
@@ -78,7 +78,7 @@ Comments
   
   A newer offering that also provides gov.uk styling and easy to configure search functionality.
 
-  The [Home Office docs-as-code template](https://github.com/UKHomeOffice/eleventy-docs-as-code-template) is a good starting point for a site with Home Office branding. It replicates the base configuration and additional styles applied to this engineering guidance and standards site, resulting in a similar look and feel.
+  The [Home Office docs-as-code template](https://github.com/UKHomeOffice/eleventy-docs-as-code-template) is a good starting point for a site with Home Office branding. It uses the base configuration and additional styles applied to this engineering guidance and standards site, resulting in a similar look and feel.
 
 Example of Home Office documentation using this option
 : - [DECS developer documentation](https://ukhomeoffice.github.io/hocs/get-started/)


### PR DESCRIPTION
Now that the Home Office docs-as-code template has been setup, we should include a link to it from the docs-as-code pattern. 

This also adds the [Developer healthcheck docs](https://ukhomeoffice.github.io/developer-healthcheck-docs/) as an additional example, which was built using the template.

# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
