### PR TITLE
Add `govuk-link` class to version permalinks

### DIFF
--- a/_includes/layouts/content.njk
+++ b/_includes/layouts/content.njk
@@ -48,7 +48,7 @@
       {% if gitHashPath %}
         <p class="govuk-body">
           {% set githubPath = page.filePathStem + '.md' %}
-          <a class="version-permalink" href="{{ gitHashPath }}{{githubPath}}" target="_blank" rel="noopener">
+          <a class="govuk-link version-permalink" href="{{ gitHashPath }}{{githubPath}}" target="_blank" rel="noopener">
             Content version permalink (GitHub) (opens in a new tab)
           </a>
         </p>


### PR DESCRIPTION
# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).
- [X] This change might impact accessibility, automated aXe tests cover the impact

## Commit signing

- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
