### PR TITLE
Fix broken link

### DIFF
--- a/docs/standards/open-source-licensing.md
+++ b/docs/standards/open-source-licensing.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Open source licensing
-date: 2023-05-24
+date: 2025-08-27
 id: SEGAS-00004
 tags:
 - Source management

--- a/docs/standards/open-source-licensing.md
+++ b/docs/standards/open-source-licensing.md
@@ -10,7 +10,7 @@ tags:
 
 Open source code repositories maintained by the Home Office must be given an appropriate licence, this explains to users the terms under which that code can be used or modified.
 
-This standard is broadly similar to the [GDS Licensing Guidelines](https://gds-way.cloudapps.digital/manuals/licensing.html#licensing) - it is in part based on that content, adopts the same convention on usage of the words 'license' and 'licence', and follows the [UK Government Licensing Framework](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/).
+This standard is broadly similar to the [GDS Licensing Guidelines](https://gds-way.digital.cabinet-office.gov.uk/manuals/licensing.html) - it is in part based on that content, adopts the same convention on usage of the words 'license' and 'licence', and follows the [UK Government Licensing Framework](https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/).
 
 ---
 


### PR DESCRIPTION
Fixes #581 
Link source: https://ukgovernmentdigital.slack.com/archives/C23NQUH3L/p1756304106728009?thread_ts=1752834609.364859&cid=C23NQUH3L
I've also removed the hash as `#licencing` is the id for the page h1, which already shows at the top of the page when following the base link.

# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
