### PR TITLE
Add focus style to header link

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,8 +1,8 @@
 import { govukEleventyPlugin } from "@x-govuk/govuk-eleventy-plugin";
 import {DateTime} from "luxon";
 import childProcess from "child_process";
-import path from "path";
-import fs from "fs";
+import path from "node:path";
+import fs from "node:fs/promises";
 import dlAsSummaryList from "./lib/markdown/dl-as-govuk-summary-list.js";
 
 function injectGitSha(eleventyConfig, gitHubRepositoryUrl) {
@@ -27,6 +27,11 @@ export default async function(eleventyConfig) {
     const _siteRoot = process.env.SITE_ROOT ?? 'http://localhost:8080/';
     const gitHubRepositoryUrl = "https://github.com/UKHomeOffice/engineering-guidance-and-standards";
 
+    // Inline logo SVG, allowing the logo elements to be targeted by CSS style rules.
+    // This is so that the purple vertical line can be switched to black when the header link has focus.
+    const svgContents = await fs.readFile('docs/assets/logos/ho_logo.svg', 'utf8');
+    const logoSvg = svgContents.replace('<?xml version="1.0" encoding="UTF-8"?>\n<svg ', '<svg height="34" aria-label="Home Office logo"');
+
     // Pass assets through to final build directory
     eleventyConfig.addPassthroughCopy({ "docs/assets/logos": "assets/logos"});
     eleventyConfig.addPassthroughCopy({ "docs/assets/images": "assets/images"});
@@ -44,7 +49,7 @@ export default async function(eleventyConfig) {
             logotype: {
                 html:
                     '<span class="govuk-header__logotype">' +
-                    '  <img src="/assets/logos/ho_logo.svg" height="34px" alt="Home Office Logo">' +
+                    logoSvg +
                     '  <span class="govuk-header__logotype-text">Home Office</span>' +
                     '</span>'
             },
@@ -120,14 +125,15 @@ export default async function(eleventyConfig) {
     });
 
     await Promise.all(
-        fs.readdirSync(path.join(process.cwd(), path.join('lib', 'filters'))).map((file) => path.parse(file))
-        .filter(({ext}) => ext === '.js')
-        .map(async ({name, base}) =>
-            eleventyConfig.addFilter(
-                name,
-                (await import(path.join(process.cwd(), 'lib', 'filters', base))).default,
+        (await fs.readdir(path.join(process.cwd(), path.join('lib', 'filters'))))
+            .map((file) => path.parse(file))
+            .filter(({ext}) => ext === '.js')
+            .map(async ({name, base}) =>
+                eleventyConfig.addFilter(
+                    name,
+                    (await import(path.join(process.cwd(), 'lib', 'filters', base))).default,
+                )
             )
-        )
     );
 
     eleventyConfig.addCollection("getAllStandardsOrderedByID", function(collectionApi) {

--- a/docs/assets/logos/ho_logo.svg
+++ b/docs/assets/logos/ho_logo.svg
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg class="hods-header__logo-svg"  preserveAspectRatio="xMinYMin" version="1.1" viewBox="81.14 80.65 62 71.15" xmlns="http://www.w3.org/2000/svg">
  <g transform="">
-  <g id="Line">
-   <rect x="81.14" y="80.65" class="st2" width="4.25" height="71.15" fill="#732282"/>
+  <g class="hods-header__logo-svg__vertical-line">
+   <rect x="81.14" y="80.65" class="st2" width="4.25" height="71.15" />
   </g>
-  <g id="Simplified_Coat_of_Arms">
+  <g id="hods-header__logo-svg__coat-of-arms">
    <g>
     <g>
      <path d="M123.07,148.04c-0.39-0.86-1.86-0.35-1.58,0.51c1.75-0.58,0.56,2.19-0.72,1.43c-0.93-0.23-0.79-2.26,0.22-1.41

--- a/docs/styles/base.scss
+++ b/docs/styles/base.scss
@@ -39,6 +39,11 @@ body, .govuk-template__body {
     color: #0b0c0c;
   }
 
+  .govuk-header__link:focus {
+    background-color: #ffdd00;
+    color: #0b0c0c;
+  }
+
   .govuk-header__logo img {
     vertical-align: bottom;
   }

--- a/docs/styles/base.scss
+++ b/docs/styles/base.scss
@@ -39,9 +39,24 @@ body, .govuk-template__body {
     color: #0b0c0c;
   }
 
-  .govuk-header__link:focus {
-    background-color: #ffdd00;
-    color: #0b0c0c;
+  .govuk-header__link {
+
+    svg {
+      vertical-align: bottom;
+    }
+
+    .hods-header__logo-svg__vertical-line {
+      fill: govuk.$govuk-brand-colour;
+    }
+
+    &:focus {
+      background-color: govuk.$govuk-focus-colour;
+      color: govuk.$govuk-focus-text-colour;
+
+      .hods-header__logo-svg__vertical-line {
+        fill: govuk.$govuk-focus-text-colour;
+      }
+    }
   }
 
   .govuk-header__logo img {


### PR DESCRIPTION
Fixes #601

# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [X] This change might impact accessibility and is not covered by automated aXe tests - manual testing has been performed
    Keyboard navigation performed to verify yellow focus indicator styling covers whole page title.

## Commit signing

- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
