### PR TITLE
Reformat list of test pyramid metrics to avoid `%` being parsed as warning text

### DIFF
--- a/docs/standards/test-pyramid.md
+++ b/docs/standards/test-pyramid.md
@@ -2,7 +2,7 @@
 layout: standard
 order: 1
 title: Test pyramid
-date: 2025-06-13
+date: 2025-10-31
 id: SEGAS-00017
 tags:
 - Quality engineering

--- a/docs/standards/test-pyramid.md
+++ b/docs/standards/test-pyramid.md
@@ -47,10 +47,10 @@ The top of the pyramid is the smallest, representing end-to-end (E2E) tests. The
 
 Capturing metrics is crucial for evaluating the effectiveness of your tests, especially when considering the test pyramid, which emphasises a large number of unit tests at the base, fewer integration tests in the middle, and even fewer end-to-end tests at the top. These metrics help identify gaps, measure performance, ensure reliability, and optimise resources, ultimately maintaining a balanced and effective test strategy that ensures robust and reliable software. Although not exhaustive - the following should be captured at a minimum across the pyramid:
 
- - Defect density
- - Test execution time
- - % of unreliable tests
- - Defect leakage across levels
- - Automation coverage
+ - defect density
+ - test execution time
+ - percentage of unreliable tests
+ - defect leakage across levels
+ - automation coverage
 
 ---


### PR DESCRIPTION
# Notes
- it is possible to escape with `\%` but using word percentage is clearer
- capitalisation as per https://www.gov.uk/guidance/style-guide/a-to-z#bullet-points-steps

# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
