### PR TITLE
Switch all pipelines to use report upload action

### DIFF
--- a/.github/workflows/deploy-to-core-cloud.yml
+++ b/.github/workflows/deploy-to-core-cloud.yml
@@ -92,7 +92,14 @@ jobs:
           retention-days: 3
 
       - name: Publish CTRF Test Summary Results
-        run: npm run playwright:publish-github-ctrf-report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: './ctrf/*.json'
+          status-check: true
+          status-check-name: 'Playwright tests'
+          upload-artifact: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
 
       - name: Sync

--- a/.github/workflows/deploy-to-staging-core-cloud.yml
+++ b/.github/workflows/deploy-to-staging-core-cloud.yml
@@ -92,7 +92,14 @@ jobs:
           retention-days: 3
 
       - name: Publish CTRF Test Summary Results
-        run: npm run playwright:publish-github-ctrf-report
+        uses: ctrf-io/github-test-reporter@v1
+        with:
+          report-path: './ctrf/*.json'
+          status-check: true
+          status-check-name: 'Playwright tests'
+          upload-artifact: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: always()
 
       - name: Sync

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -91,7 +91,7 @@ jobs:
         with:
           report-path: './ctrf/*.json'
           status-check: true
-          status-check-name: 'GitHub Test Reporter Results'
+          status-check-name: 'Playwright tests'
           upload-artifact: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`npm run playwright:publish-github-ctrf-report` was removed because it relied on an unmaintained repository with reported vulnerabilities. This switches the staging and prod deploys to use the `ctrf-io/github-test-reporter` action to match the e2e test pipeline.

# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).
- [X] This change will not change layouts, page structures or anything else that might impact accessibility

## Commit signing

- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)