### PR TITLE
Issue #347 initial commit - Automate to eliminate manual steps Principle

### DIFF
--- a/docs/principles/automate-to-eliminate-manual-steps.md
+++ b/docs/principles/automate-to-eliminate-manual-steps.md
@@ -1,0 +1,39 @@
+---
+layout: principle
+order: 1
+title: Automate to eliminate manual steps
+date: 2026-02-13
+tags:
+- Automation
+- Ways of working
+- Operations
+- Sre
+- Quality engineering
+related:
+- /standards/writing-a-principle/
+---
+ 
+## Description
+Manual processes increase operational cost, introduce human error and slow teams down. Designing for automation from the outset results in more reliable, maintainable and scalable systems. This principle encourages teams to minimise toil by removing manual steps in the design, build and operation of services, tooling and platforms.
+ 
+By making automation an expected part of delivery, services become easier to run and support, enabling engineering teams to focus on delivering value rather than performing repetitive tasks.
+ 
+## Rationale
+Services often reach live service without the necessary administration tooling, creating avoidable burdens on engineers. This results in time-consuming manual work, higher error rates and increased long‑term costs.
+ 
+Eliminating toil is a core concept of Site Reliability Engineering, enabling more sustainable and higher‑quality operations. Automating operational tasks improves repeatability, reduces risk and helps teams scale effectively.
+ 
+## Applications and implications
+ 
+### Applications
+- Automate repeatable operational tasks wherever possible.
+- Consider operational cost and required automation early in architecture and design, not after go‑live.
+- Ensure new services include necessary administration or operational tooling as part of initial delivery.
+- Apply automation consistently across external‑facing services, internal tooling, infrastructure and platforms.
+- Evaluate automation maturity when onboarding services from third‑party suppliers.
+- Refer to SRE *Eliminating Toil* guidance when identifying suitable automation candidates.
+ 
+### Implications
+- Teams may need to make upfront investments in automation to reduce longer‑term operational costs.
+- Some services may require improved tooling or refactoring to minimise manual administration.
+**- Automation should be treated as a core requirement, not an optional enhancement.**orking, Operations, SRE, Quality engineering

--- a/docs/principles/automate-to-eliminate-manual-steps.md
+++ b/docs/principles/automate-to-eliminate-manual-steps.md
@@ -7,7 +7,7 @@ tags:
 - Automation
 - Ways of working
 - Operations
-- Sre
+- SRE
 - Quality engineering
 related:
 - /standards/writing-a-principle/

--- a/docs/principles/automate-to-eliminate-manual-steps.md
+++ b/docs/principles/automate-to-eliminate-manual-steps.md
@@ -9,8 +9,8 @@ tags:
 - Operations
 - SRE
 - Quality engineering
+- Build, release and deploy
 related:
-- /standards/writing-a-principle/
 ---
  
 ## Description
@@ -36,4 +36,4 @@ Eliminating toil is a core concept of Site Reliability Engineering, enabling mor
 ### Implications
 - Teams may need to make upfront investments in automation to reduce longer‑term operational costs.
 - Some services may require improved tooling or refactoring to minimise manual administration.
-**- Automation should be treated as a core requirement, not an optional enhancement.**orking, Operations, SRE, Quality engineering
+- Automation should be treated as a core requirement, not an optional enhancement.

--- a/docs/principles/automate-to-eliminate-manual-steps.md
+++ b/docs/principles/automate-to-eliminate-manual-steps.md
@@ -10,7 +10,6 @@ tags:
 - SRE
 - Quality engineering
 - Build, release and deploy
-related:
 ---
  
 ## Description


### PR DESCRIPTION
Is this pull request a content or a code change? (Please fill in the relevant section and delete the other)

# Code change
I can confirm:
## Accessibility considerations
- [x] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [ ] This change will not change layouts, page structures or anything else that might impact accessibility

or
- [ ] This change might impact accessibility, automated aXe tests cover the impact

or
- [ ] This change might impact accessibility and is not covered by automated aXe tests - manual testing has been performed
(If the change might impact accessibility then please add some further information here)

## Commit signing

- [x] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)

# Content change 
- [x] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [ ] Content does not include any code or configuration changes (excluding frontmatter information)
- [x] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [x] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [ ] Last updated date for content is correct
- [x] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
