### PR TITLE
Duplicate LDP0wer's PR on logging standards

### DIFF
--- a/docs/patterns/securing-application-logging.md
+++ b/docs/patterns/securing-application-logging.md
@@ -3,13 +3,13 @@ layout: pattern
 order: 1
 title: Securing application logging
 date: 2023-08-11
-tags: 
+tags:
   - Logging
   - Observability
   - Secure development
   - SRE
   - Security
-  - Software design   
+  - Software design
 related:
   sections:
     - title: Related links
@@ -65,7 +65,21 @@ Logging full payloads should be avoided. However, logging full payloads can be u
 
 ## Considerations
 
+### Consider how information can combine to form PII
+
+Examples of combined PII include:
+
+- Passport number, Issuing Country, Expiry Dates
+- Biometric residence permit or card (BRP/C) number, Date of Birth
+
+With the examples above, the information by themselves do not mean very much. After all, a BRP/C number is a random sequence of characters; but in combination with the date of birth it can be used to uniquely identify an individual.
+
+If you are unsure what is person identifiable information, consult with your security specialists.
+
+Information and data sets that contain sensitive information should not be output to logs regardless of log level.
+
 ### Consider whether logging statements are necessary
+
 Sometimes logging is used for fast-feedback loops when prototyping application functionality, but eventually become redundant, or the application they provide does not provide additional operational or debugging value for an operator searching through logs.
 
 Consider removing logging statements that do not produce value. Often logging is provided to increase confidence in an application's correctness, or to provide data points around edge cases of validation and data processing. Most of these cases can be replaced with unit or integration testing instead, as appropriate.

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -2,8 +2,8 @@
 layout: standard
 order: 1
 title: Logging for services with centralised logging aggregation
-date: 2024-01-24
-id: SEGAS-00015
+date: 2026-04-10
+id: SEGAS-00019
 tags:
   - SRE
   - Monitoring

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -29,7 +29,7 @@ Logs are not a replacement for dedicated monitoring tooling. They should be used
 - [Service logs MUST be forwarded to log aggregators](#service-logs-must-be-forwarded-to-log-aggregators)
 - [Service logs MUST be rotated daily and no more than 100 MB of logs to be retained](#service-logs-must-be-rotated-daily-and-no-more-than-100-mb-of-logs-to-be-retained)
 - [Service logs MUST have an identifiable source in the log aggregator](#service-logs-must-have-an-identifiable-source-in-the-log-aggregator)
-- [Service log messages should only be used for metrics, dashboarding and alerting as a last resort](#service-log-messages-should-only-be-used-for-metrics%2C-dashboarding-and-alerting-as-a-last-resort)
+- [Service log messages MUST only be used for metrics, dashboarding and alerting as a last resort](#service-log-messages-must-only-be-used-for-metrics%2C-dashboarding-and-alerting-as-a-last-resort)
 - [There MUST be no DEBUG / TRACE level messages in Production environments](#there-must-be-no-debug-%2F-trace-level-messages-in-production-environments)
 - [Service log messages MUST not reveal any sensitive information or person identifiable information](#service-log-messages-must-not-reveal-any-sensitive-information-or-person-identifiable-information)
 
@@ -54,7 +54,7 @@ Where log files are persisted locally, log files must be rotated to prevent fill
 
 Services can have a variety of logs, including application, error, and access logs; so it must be possible to identify the source of the log data in the log aggregation tooling.
 
-### Service log messages should only be used for metrics, dashboarding and alerting as a last resort
+### Service log messages MUST only be used for metrics, dashboarding and alerting as a last resort
 
 Although acceptable in some cases, it is strongly recommended that you do not use information contained in log messages as the primary method by which you report on application health, performance and business metrics. Information in logs can be difficult to parse, aggregate and quite brittle.
 

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -1,0 +1,71 @@
+---
+layout: standard
+order: 1
+title: Logging for services with centralised logging aggregation
+date: 2024-01-24
+id: SEGAS-00015
+tags:
+  - SRE
+  - Monitoring
+  - Observability
+  - Logging
+related:
+  sections:
+    - title: Securing application logging
+      items:
+        - text: Securing application logging
+          href: /patterns/securing-application-logging/
+---
+
+Logging tools are one of the primary tools to debug application problems and identifying the root cause of incidents. Logs need to be formatted in a standard way so that they are useful for the both application's developers and those supporting the application later in its life-cycle.
+
+Logs are not a replacement for dedicated monitoring tooling. They should be used as part of a broader observabilty toolset. This standard provides guidance on a standard format for application logs, and suitable uses.
+
+---
+
+## Requirements
+
+- [Service logs MUST have the minimum required field](#service-logs-must-have-the-minimum-required-fields)
+- [Service logs MUST be forwarded to log aggregators](#service-logs-must-be-forwarded-to-log-aggregators)
+- [Service logs MUST be rotated daily and no more than 100 MB of logs to be retained](#service-logs-must-be-rotated-daily-and-no-more-than-100-mb-of-logs-to-be-retained)
+- [Service logs MUST have an identifiable source in the log aggregator](#service-logs-must-have-an-identifiable-source-in-the-log-aggregator)
+- [Service log messages should only be used for metrics, dashboarding and alerting as a last resort](#service-log-messages-should-only-be-used-for-metrics%2C-dashboarding-and-alerting-as-a-last-resort)
+- [There MUST be no DEBUG / TRACE level messages in Production environments](#there-must-be-no-debug-%2F-trace-level-messages-in-production-environments)
+- [Service log messages MUST not reveal any sensitive information or person identifiable information](#service-log-messages-must-not-reveal-any-sensitive-information-or-person-identifiable-information)
+
+### Service logs MUST have the minimum required fields
+
+| Information | Description                                                                                                                                                                                   |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Date / Time | Each log message must include date and time (millisecond accuracy) (UTC). The time source for all service logs must be consistent so that messages can be viewed & sorted easily.             |
+| Service     | Each log message must be attributed to an service (i.e. hostname).                                                                                                                            |
+| Log level   | Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)                                                                                                                 |
+| Log Message | Each log message must have a log message. Log messages must follow a consistent log messaging format for all log types to allow for easy processing and translation of logs to other formats. |
+
+### Service logs MUST be forwarded to log aggregators
+
+Service logs must be forwarded to the supported log aggregation tooling for centralised and persistent storage, and ease of querying log information across distributed applications and services.
+
+### Service logs MUST be rotated daily and no more than 100 MB of logs to be retained
+
+Where log files are persisted locally, log files must be rotated to prevent filling up local disk space. Furthermore, no more than 100 MB of logs are to be persisted should your service generate lots of logs.
+
+### Service logs MUST have an identifiable source in the log aggregator
+
+Services can have a variety of logs, including application, error, and access logs; so it must be possible to identify the source of the log data in the log aggregation tooling.
+
+### Service log messages should only be used for metrics, dashboarding and alerting as a last resort
+
+Although acceptable in some cases, it is strongly recommended that you do not use information contained in log messages as the primary method by which you report on application health, performance and business metrics. Information in logs can be difficult to parse, aggregate and quite brittle.
+
+The use of your approved tooling for service monitoring and alerting should always be prioritised over the use of log-based monitoring.
+
+### There MUST be no DEBUG / TRACE level messages in Production environments
+
+Refer to our [securing application logging]({{ '/patterns/securing-application-logging/#take-care-when-using-detailed-logging-to-support-application-debugging' | url }}) pattern for more details.
+
+### Service log messages MUST not reveal any sensitive information or person identifiable information
+
+Refer to our [securing application logging]({{ '/patterns/securing-application-logging/#consider-how-information-can-combine-to-form-pii' | url }}) pattern for more details.
+
+---

--- a/docs/standards/logging.md
+++ b/docs/standards/logging.md
@@ -35,12 +35,17 @@ Logs are not a replacement for dedicated monitoring tooling. They should be used
 
 ### Service logs MUST have the minimum required fields
 
-| Information | Description                                                                                                                                                                                   |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Date / Time | Each log message must include date and time (millisecond accuracy) (UTC). The time source for all service logs must be consistent so that messages can be viewed & sorted easily.             |
-| Service     | Each log message must be attributed to an service (i.e. hostname).                                                                                                                            |
-| Log level   | Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)                                                                                                                 |
-| Log Message | Each log message must have a log message. Log messages must follow a consistent log messaging format for all log types to allow for easy processing and translation of logs to other formats. |
+Date / Time
+: Each log message must include date and time (millisecond accuracy) (UTC). The time source for all service logs must be consistent so that messages can be viewed & sorted easily.
+
+Service
+: Each log message must be attributed to an service (i.e. hostname).
+
+Log level
+: Each log message must have an appropriate log level (INFO, WARN, ERROR, etc.)
+
+Log Message
+: Each log message must have a log message. Log messages must follow a consistent log messaging format for all log types to allow for easy processing and translation of logs to other formats.
 
 ### Service logs MUST be forwarded to log aggregators
 


### PR DESCRIPTION
A PR to create a new set of Standards for application logging, based on those that exist in MBTP already.

# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [X] Last updated date for content is correct
