### PR TITLE
Update CONTRIBUTING.md with commit signing fix instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,14 @@ Please make sure you have set up Git to sign your commits with a method that Git
 If you have already pushed a commit that is unsigned, you can rectify this in two ways:
 
 1. Once commit signing is set up, rebase your work onto the main branch, then force push the changes. As with any force push, if you think others may have your branch checked out please make sure they are aware, e.g. with a comment on the pull request, so that they can update their local branches. This is usually not an issue for SEGAS contributions, as other collaborators work through the GitHub web interface rather than locally checked out versions.
-2. Create a new branch from the main branch, re-apply your changes to that branch, submit a new PR, and close the old one. This is usually more work, but can be simpler to manage if there are multiple contributors, or a complex commit history.
+    ```shell
+    # start an interactive rebase that signs all commits, even ones that are unchanged by the rebase
+    git rebase --exec 'git commit --amend --no-edit --gpg-sign' -i origin/main
+    # force push the new branch if no-one else has pushed commits since you checked out
+    git push --force-with-lease
+    ```
+
+3. Create a new branch from the main branch, re-apply your changes to that branch, submit a new PR, and close the old one. This is usually more work, but can be simpler to manage if there are multiple contributors, or a complex commit history.
 
 ## Pull Requests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ If you have already pushed a commit that is unsigned, you can rectify this in tw
     git push --force-with-lease
     ```
 
-3. Create a new branch from the main branch, re-apply your changes to that branch, submit a new PR, and close the old one. This is usually more work, but can be simpler to manage if there are multiple contributors, or a complex commit history.
+2. Create a new branch from the main branch, re-apply your changes to that branch, submit a new PR, and close the old one. This is usually more work, but can be simpler to manage if there are multiple contributors, or a complex commit history.
 
 ## Pull Requests
 


### PR DESCRIPTION
Added command line instructions for signing previously unsigned commits with an interactive rebase.

Is this pull request a content or a code change? (Please fill in the relevant section and delete the other)

# Content change 
- [X] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [X] Content does not include any code or configuration changes (excluding frontmatter information)
- [X] Content meets the content standards
- [X] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [-] Last updated date for content is correct
    - _Repository content doesn't have last updated_ 
- [x] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
