### PR TITLE
feat: expand API documentation with OpenAPI spec and Swagger #620

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -35,6 +35,9 @@ export default async function(eleventyConfig) {
     // Pass assets through to final build directory
     eleventyConfig.addPassthroughCopy({ "docs/assets/logos": "assets/logos"});
     eleventyConfig.addPassthroughCopy({ "docs/assets/images": "assets/images"});
+    // Pass through OpenAPI spec for Swagger UI
+    eleventyConfig.addPassthroughCopy('docs/openapi.yaml');
+
     // Register the plugins
     let govukPluginOptions = {
         icons: {
@@ -84,6 +87,10 @@ export default async function(eleventyConfig) {
                     {
                         href: '/accessibility-statement/',
                         text: 'Accessibility'
+                    },
+                    {
+                        href: '/api/',
+                        text: 'API reference'
                     },
                     {
                         href: gitHubRepositoryUrl,

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TEST_URL: http://localhost
+  TEST_URL: localhost
   TEST_PORT: 8080
 
 jobs:

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -53,12 +53,14 @@ jobs:
         run: |
           elapsed=0
 
-          while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://${{ env.TEST_URL }}:${{ env.TEST_PORT }})" != "200" ]]; do
+          while [[ "$(curl -s -o /dev/null -w '%{http_code}' "http://${TEST_URL}:${TEST_PORT}")" != "200" ]] || \
+                [[ "$(curl -s -o /dev/null -w '%{http_code}' "http://${TEST_URL}:${TEST_PORT}/openapi.yaml")" != "200" ]] || \
+                [[ "$(curl -s -o /dev/null -w '%{http_code}' "http://${TEST_URL}:${TEST_PORT}/api/standards.json")" != "200" ]]; do
             sleep 1
             ((elapsed++))
 
-            if [[ $elapsed -ge ${{ env.TIMEOUT_SECS }} ]]; then
-              echo "Timeout waiting for http://${{ env.TEST_URL }}:${{ env.TEST_PORT }})"
+            if [[ $elapsed -ge $TIMEOUT_SECS ]]; then
+              echo "Timeout waiting for API readiness on http://${TEST_URL}:${TEST_PORT}"
               exit 1
             fi
           done

--- a/.github/workflows/e2e-tests-on-pr.yml
+++ b/.github/workflows/e2e-tests-on-pr.yml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  TEST_URL: localhost
+  TEST_URL: http://localhost
   TEST_PORT: 8080
 
 jobs:

--- a/_data/homepageLinks.js
+++ b/_data/homepageLinks.js
@@ -21,5 +21,12 @@ export default async () => {
             await fromPage('principles'),
             await fromPage('standards'),
             await fromPage('patterns'),
+            {
+                url: '/api/',
+                id: 'api',
+                data: {
+                    title: 'API Reference',
+                },
+            },
     ];
 }

--- a/docs/api.html
+++ b/docs/api.html
@@ -1,0 +1,23 @@
+---
+layout: page
+title: API Reference
+---
+
+<!-- Swagger UI CDN -->
+<link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css">
+<div id="swagger-ui"></div>
+<script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+<script>
+  window.onload = function() {
+    window.ui = SwaggerUIBundle({
+      url: '/openapi.yaml',
+      dom_id: '#swagger-ui',
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset
+      ],
+      layout: "BaseLayout",
+      deepLinking: true
+    });
+  };
+</script>

--- a/docs/api/patterns.11ty.js
+++ b/docs/api/patterns.11ty.js
@@ -1,0 +1,31 @@
+import isoDateOnly from '../../lib/filters/isoDateOnly.js';
+import prefixWithRoot from '../../lib/filters/prefixWithRoot.js';
+
+export default class {
+  data() {
+    return {
+      eleventyExcludeFromCollections: true,
+      pagination: {
+        data: 'collections.getAllPatternsOrderedByTitle',
+        size: 1,
+        alias: 'pattern'
+      },
+      permalink: data => `/api/patterns/${data.pattern.fileSlug}.json`
+    };
+  }
+
+  render(data) {
+    const pattern = data.pattern;
+
+    return JSON.stringify({
+      pattern: {
+        id: pattern.fileSlug,
+        title: pattern.data.title,
+        url: prefixWithRoot(pattern.url, data.siteRoot),
+        date: isoDateOnly(pattern.data.date),
+        tags: pattern.data.tags,
+        requirements: []
+      }
+    }, null, 2);
+  }
+}

--- a/docs/api/patterns.njk
+++ b/docs/api/patterns.njk
@@ -1,0 +1,19 @@
+---
+permalink: /api/patterns/
+eleventyExcludeFromCollections: true
+---
+{
+  "patterns": [
+    {% for item in collections.getAllPatternsOrderedByTitle %}
+    {
+      "id": {{ item.fileSlug | dump }},
+      "title": {{ item.data.title | dump }},
+      "url": {{ item.url | prefixWithRoot(siteRoot) | dump }},
+      "date": {{ item.data.date | dump }},
+      "tags": {{ item.data.tags | dump }},
+      "requirements": []
+    }{% if not loop.last %},
+    {% endif %}
+    {% endfor %}
+  ]
+}

--- a/docs/api/principles.11ty.js
+++ b/docs/api/principles.11ty.js
@@ -1,0 +1,31 @@
+import isoDateOnly from '../../lib/filters/isoDateOnly.js';
+import prefixWithRoot from '../../lib/filters/prefixWithRoot.js';
+
+export default class {
+  data() {
+    return {
+      eleventyExcludeFromCollections: true,
+      pagination: {
+        data: 'collections.getAllPrinciplesOrderedByTitle',
+        size: 1,
+        alias: 'principle'
+      },
+      permalink: data => `/api/principles/${data.principle.fileSlug}.json`
+    };
+  }
+
+  render(data) {
+    const principle = data.principle;
+
+    return JSON.stringify({
+      principle: {
+        id: principle.fileSlug,
+        title: principle.data.title,
+        url: prefixWithRoot(principle.url, data.siteRoot),
+        date: isoDateOnly(principle.data.date),
+        tags: principle.data.tags,
+        requirements: []
+      }
+    }, null, 2);
+  }
+}

--- a/docs/api/principles.njk
+++ b/docs/api/principles.njk
@@ -1,0 +1,19 @@
+---
+permalink: /api/principles/
+eleventyExcludeFromCollections: true
+---
+{
+  "principles": [
+    {% for item in collections.getAllPrinciplesOrderedByTitle %}
+    {
+      "id": {{ item.fileSlug | dump }},
+      "title": {{ item.data.title | dump }},
+      "url": {{ item.url | prefixWithRoot(siteRoot) | dump }},
+      "date": {{ item.data.date | dump }},
+      "tags": {{ item.data.tags | dump }},
+      "requirements": []
+    }{% if not loop.last %},
+    {% endif %}
+    {% endfor %}
+  ]
+}

--- a/docs/api/standards.11ty.js
+++ b/docs/api/standards.11ty.js
@@ -1,0 +1,32 @@
+import extractRequirements from '../../lib/filters/extractRequirements.js';
+import isoDateOnly from '../../lib/filters/isoDateOnly.js';
+import prefixWithRoot from '../../lib/filters/prefixWithRoot.js';
+
+export default class {
+  data() {
+    return {
+      eleventyExcludeFromCollections: true,
+      pagination: {
+        data: 'collections.getAllStandardsOrderedByID',
+        size: 1,
+        alias: 'standard'
+      },
+      permalink: data => `/api/standards/${data.standard.data.id}.json`
+    };
+  }
+
+  render(data) {
+    const standard = data.standard;
+
+    return JSON.stringify({
+      standard: {
+        id: standard.data.id,
+        title: standard.data.title,
+        url: prefixWithRoot(standard.url, data.siteRoot),
+        date: isoDateOnly(standard.data.date),
+        tags: standard.data.tags,
+        requirements: extractRequirements(standard.templateContent)
+      }
+    }, null, 2);
+  }
+}

--- a/docs/api/standards.njk
+++ b/docs/api/standards.njk
@@ -1,0 +1,19 @@
+---
+permalink: /api/standards/
+eleventyExcludeFromCollections: true
+---
+{
+  "standards": [
+    {% for standard in collections.getAllStandardsOrderedByID %}
+    {
+      "id": {{ standard.data.id | dump }},
+      "title": {{ standard.data.title | dump }},
+      "url": {{ standard.url | prefixWithRoot(siteRoot) | dump }},
+      "date": {{ standard.data.date | isoDateOnly | dump }},
+      "tags": {{ standard.data.tags | dump }},
+      "requirements": {{ standard.templateContent | extractRequirements | dump }}
+    }{% if not loop.last %},
+    {% endif %}
+    {% endfor %}
+  ]
+}

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1,0 +1,241 @@
+openapi: 3.0.3
+info:
+  title: Engineering Guidance and Standards API
+  description: |
+    OpenAPI specification for the Engineering Guidance and Standards API. This API provides access to standards, principles, and patterns.
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080/api
+    description: Local development server
+  - url: https://engineering.homeoffice.gov.uk/api
+    description: Production server
+paths:
+  /standards.json:
+    get:
+      tags:
+        - Standards
+      operationId: getStandards
+      summary: Get all standards
+      responses:
+        '200':
+          description: A list of standards
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StandardList'
+  /standards/{standardId}.json:
+    get:
+      tags:
+        - Standards
+      operationId: getStandard
+      summary: Get a standard by ID
+      parameters:
+        - name: standardId
+          in: path
+          required: true
+          description: The SEGAS identifier for the standard
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A single standard
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  standard:
+                    $ref: '#/components/schemas/Standard'
+  /principles.json:
+    get:
+      tags:
+        - Principles
+      operationId: getPrinciples
+      summary: Get all principles
+      responses:
+        '200':
+          description: A list of principles
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PrincipleList'
+  /principles/{principleId}.json:
+    get:
+      tags:
+        - Principles
+      operationId: getPrinciple
+      summary: Get a principle by ID
+      parameters:
+        - name: principleId
+          in: path
+          required: true
+          description: The slug for the principle
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A single principle
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  principle:
+                    $ref: '#/components/schemas/Principle'
+  /patterns.json:
+    get:
+      tags:
+        - Patterns
+      operationId: getPatterns
+      summary: Get all patterns
+      responses:
+        '200':
+          description: A list of patterns
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PatternList'
+  /patterns/{patternId}.json:
+    get:
+      tags:
+        - Patterns
+      operationId: getPattern
+      summary: Get a pattern by ID
+      parameters:
+        - name: patternId
+          in: path
+          required: true
+          description: The slug for the pattern
+          schema:
+            type: string
+      responses:
+        '200':
+          description: A single pattern
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pattern:
+                    $ref: '#/components/schemas/Pattern'
+components:
+  schemas:
+    StandardList:
+      type: object
+      properties:
+        standards:
+          type: array
+          items:
+            $ref: '#/components/schemas/Standard'
+    PrincipleList:
+      type: object
+      properties:
+        principles:
+          type: array
+          items:
+            $ref: '#/components/schemas/Principle'
+    PatternList:
+      type: object
+      properties:
+        patterns:
+          type: array
+          items:
+            $ref: '#/components/schemas/Pattern'
+    Standard:
+      type: object
+      required:
+        - id
+        - title
+        - url
+        - date
+        - tags
+        - requirements
+      properties:
+        id:
+          type: string
+          description: A unique ID for the specification (e.g., SEGAS-00001)
+          pattern: ^SEGAS-\d{5}$
+        title:
+          type: string
+          description: A short title describing the subject of the specification
+        url:
+          type: string
+          description: The url for the standard's documentation
+        date:
+          type: string
+          description: The date this standard was last updated or reviewed (ISO8601)
+          pattern: ^\d{4}-\d{2}-\d{2}$
+        tags:
+          type: array
+          description: The tags assigned to this standard
+          items:
+            type: string
+        requirements:
+          type: array
+          description: A list of requirements to meet this standard
+          items:
+            $ref: '#/components/schemas/Requirement'
+    Requirement:
+      type: object
+      required:
+        - title
+        - id
+      properties:
+        title:
+          type: string
+          description: A short description of the requirement
+        id:
+          type: string
+          description: The html id of this requirement within the standard's documentation page.
+    Principle:
+      type: object
+      required:
+        - id
+        - title
+        - url
+        - date
+        - tags
+        - requirements
+      properties:
+        id:
+          type: string
+        url:
+          type: string
+        title:
+          type: string
+        date:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        requirements:
+          type: array
+          items:
+            $ref: '#/components/schemas/Requirement'
+    Pattern:
+      type: object
+      required:
+        - id
+        - title
+        - url
+        - date
+        - tags
+        - requirements
+      properties:
+        id:
+          type: string
+        url:
+          type: string
+        title:
+          type: string
+        date:
+          type: string
+        tags:
+          type: array
+          items:
+            type: string
+        requirements:
+          type: array
+          items:
+            type: object

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -8,6 +8,12 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: 2,
   workers: 5,
+  webServer: {
+    command: 'npm run serve',
+    url: 'http://127.0.0.1:8080',
+    reuseExistingServer: true,
+    timeout: 120000,
+  },
 
   reporter: [
     ['html', { outputFolder: 'playwright-report', open: 'never' }],
@@ -15,7 +21,7 @@ export default defineConfig({
   ],
 
   use: {
-    baseURL: process.env.TEST_URL ?? 'http://localhost',
+    baseURL: process.env.TEST_URL ?? 'http://127.0.0.1',
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',

--- a/tests/e2e/api.spec.js
+++ b/tests/e2e/api.spec.js
@@ -1,0 +1,112 @@
+import { test, expect } from '@playwright/test';
+import { testing_params } from '../support/testing_params';
+
+async function getJson(page, path) {
+  const response = await page.request.get(`${testing_params.TEST_ROOT_URL}${path}`);
+  expect(response.ok()).toBeTruthy();
+  expect(response.headers()['content-type']).toContain('application/json');
+  return response.json();
+}
+
+test.describe('API documentation', () => {
+  test('Swagger UI loads the OpenAPI spec', async ({ page }) => {
+    await page.goto(`${testing_params.TEST_ROOT_URL}/api/`);
+
+    await expect(page).toHaveTitle(/API Reference/);
+    await expect(page.locator('#swagger-ui')).toBeVisible();
+    await expect(page.locator('link[href*="swagger-ui.css"]')).toHaveCount(1);
+    await expect(page.locator('script[src*="swagger-ui-bundle.js"]')).toHaveCount(1);
+  });
+
+  test('OpenAPI spec includes the API endpoints', async ({ page }) => {
+    const response = await page.request.get(`${testing_params.TEST_ROOT_URL}/openapi.yaml`);
+
+    expect(response.ok()).toBeTruthy();
+    const openApi = await response.text();
+
+    expect(openApi).toContain('/standards.json');
+    expect(openApi).toContain('/standards/{standardId}.json');
+    expect(openApi).toContain('/principles.json');
+    expect(openApi).toContain('/principles/{principleId}.json');
+    expect(openApi).toContain('/patterns.json');
+    expect(openApi).toContain('/patterns/{patternId}.json');
+    expect(openApi).toContain('tags:');
+  });
+});
+
+test.describe('API endpoints', () => {
+  test('returns the standards collection and a single standard', async ({ page }) => {
+    const standards = await getJson(page, '/api/standards.json');
+
+    expect(standards.standards).toBeInstanceOf(Array);
+    expect(standards.standards.length).toBeGreaterThan(0);
+    expect(standards.standards[0]).toMatchObject({
+      id: expect.stringMatching(/^SEGAS-\d{5}$/),
+      title: expect.any(String),
+      url: expect.stringMatching(/^http:\/\/localhost:8080\/standards\//),
+      date: expect.any(String),
+      tags: expect.any(Array),
+      requirements: expect.any(Array)
+    });
+
+    const standard = await getJson(page, '/api/standards/SEGAS-00001.json');
+    expect(standard.standard).toMatchObject({
+      id: 'SEGAS-00001',
+      title: 'Writing a standard',
+      url: 'http://localhost:8080/standards/writing-a-standard/',
+      date: '2023-08-04',
+      tags: [],
+    });
+    expect(standard.standard.requirements).toHaveLength(6);
+  });
+
+  test('returns the principles collection and a single principle', async ({ page }) => {
+    const principles = await getJson(page, '/api/principles.json');
+
+    expect(principles.principles).toBeInstanceOf(Array);
+    expect(principles.principles.length).toBeGreaterThan(0);
+    expect(principles.principles[0]).toMatchObject({
+      id: expect.any(String),
+      title: expect.any(String),
+      url: expect.stringMatching(/^http:\/\/localhost:8080\/principles\//),
+      date: expect.any(String),
+      tags: expect.any(Array),
+      requirements: []
+    });
+
+    const principle = await getJson(page, '/api/principles/be-collaborative.json');
+    expect(principle.principle).toMatchObject({
+      id: 'be-collaborative',
+      title: 'Be collaborative',
+      url: 'http://localhost:8080/principles/be-collaborative/',
+      date: '2023-06-22',
+      tags: ['Software design', 'Ways of working'],
+      requirements: []
+    });
+  });
+
+  test('returns the patterns collection and a single pattern', async ({ page }) => {
+    const patterns = await getJson(page, '/api/patterns.json');
+
+    expect(patterns.patterns).toBeInstanceOf(Array);
+    expect(patterns.patterns.length).toBeGreaterThan(0);
+    expect(patterns.patterns[0]).toMatchObject({
+      id: expect.any(String),
+      title: expect.any(String),
+      url: expect.stringMatching(/^http:\/\/localhost:8080\/patterns\//),
+      date: expect.any(String),
+      tags: expect.any(Array),
+      requirements: []
+    });
+
+    const pattern = await getJson(page, '/api/patterns/code-reviews.json');
+    expect(pattern.pattern).toMatchObject({
+      id: 'code-reviews',
+      title: 'Code reviews',
+      url: 'http://localhost:8080/patterns/code-reviews/',
+      date: '2025-04-10',
+      tags: ['Software design', 'Ways of working'],
+      requirements: []
+    });
+  });
+});

--- a/tests/e2e/api.spec.js
+++ b/tests/e2e/api.spec.js
@@ -2,7 +2,16 @@ import { test, expect } from '@playwright/test';
 import { testing_params } from '../support/testing_params';
 
 async function getJson(page, path) {
-  const response = await page.request.get(`${testing_params.TEST_ROOT_URL}${path}`);
+  const requestUrl = `${testing_params.TEST_ROOT_URL}${path}`;
+  const response = await page.request.get(requestUrl);
+
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(
+      `GET ${requestUrl} failed with ${response.status()} ${response.statusText()}\n${body.slice(0, 500)}`
+    );
+  }
+
   expect(response.ok()).toBeTruthy();
   expect(response.headers()['content-type']).toContain('application/json');
   return response.json();

--- a/tests/support/testing_params.js
+++ b/tests/support/testing_params.js
@@ -1,5 +1,5 @@
 export const testing_params = {
-  TEST_URL: process.env.TEST_URL ?? 'http://localhost',
+  TEST_URL: process.env.TEST_URL ?? 'http://127.0.0.1',
   TEST_PORT: process.env.TEST_PORT ?? '8080',
   TEST_PATH: process.env.TEST_PATH ?? '',
   

--- a/tests/support/testing_params.js
+++ b/tests/support/testing_params.js
@@ -2,8 +2,12 @@ export const testing_params = {
   TEST_URL: process.env.TEST_URL ?? 'http://127.0.0.1',
   TEST_PORT: process.env.TEST_PORT ?? '8080',
   TEST_PATH: process.env.TEST_PATH ?? '',
+
+  get NORMALIZED_TEST_URL() {
+    return /^https?:\/\//i.test(this.TEST_URL) ? this.TEST_URL : `http://${this.TEST_URL}`;
+  },
   
   get TEST_ROOT_URL() {
-    return `${this.TEST_URL}:${this.TEST_PORT}${this.TEST_PATH.replace(/\/$/, '')}`;
+    return `${this.NORMALIZED_TEST_URL}:${this.TEST_PORT}${this.TEST_PATH.replace(/\/$/, '')}`;
   }
 };


### PR DESCRIPTION
This pull request introduces a public, documented JSON API for standards, principles, and patterns, along with automated end-to-end tests and a Swagger UI-based API documentation page. The changes include new API endpoints, OpenAPI documentation, navigation updates, and Playwright tests to ensure correctness and visibility.

**API Implementation and Documentation:**

* Added JSON API endpoints for standards, principles, and patterns (both collections and individual items) using new `.11ty.js` and `.njk` files in the `docs/api` directory. These endpoints provide structured data with fields like `id`, `title`, `url`, `date`, `tags`, and `requirements`. [[1]](diffhunk://#diff-8c6d6893c713f7de1b0d762462cc6fa2bb4a353cc25ae1ad08eaf268c8701cabR1-R32) [[2]](diffhunk://#diff-30c73d348abb21bb3ce1708e318cb8bfda0df2abbd307ba5e2f74531ce22b097R1-R19) [[3]](diffhunk://#diff-4c472e289c8aebead5e2d2ba27f504423b45ce3a76ad83fe799f84b3dd58e241R1-R31) [[4]](diffhunk://#diff-4e80d202f51283e5aa366e757392c2b0fa6429d7cda4ec040beeb31b47647a7aR1-R19) [[5]](diffhunk://#diff-ef3c7b57f380044d0810a14c8628fa777272011de8d8d02e57dc6cf3b89a874fR1-R31) [[6]](diffhunk://#diff-de475a005a8bec0d05b8d6d724297f48192845d3aed00a992bff68d283af3cfbR1-R19)
* Introduced an OpenAPI 3.0.3 specification (`docs/openapi.yaml`) describing all API endpoints, schemas, and parameters for standards, principles, and patterns.
* Added an API documentation page at `/api/` (`docs/api.html`) that loads the OpenAPI spec in Swagger UI, making the API self-documenting and explorable.

**Navigation and Discovery:**

* Updated site navigation and homepage links to include the new API reference page, making the API easily discoverable for users. [[1]](diffhunk://#diff-c306e0a99961a16f5c5c83996caa0958b94006d97f97475049ea3a08036bb5b0R91-R94) [[2]](diffhunk://#diff-0b58d2b46f6d6460219289c1b1e75a5dbef9f712e8a748c137c90aa62006d5caR24-R30)

**Build and Asset Handling:**

* Configured Eleventy to pass through the OpenAPI YAML file so it is available for Swagger UI and external clients.

**Testing and Quality Assurance:**

* Added Playwright end-to-end tests for the API endpoints and documentation, verifying both the Swagger UI and the correctness of the JSON responses.
* Updated Playwright configuration and test parameters to use `127.0.0.1` as the base URL and ensured the dev server is started for tests. [[1]](diffhunk://#diff-8421b2f4ad242eb670ea84ae0057d8708f0370adad5ac063da20b8abc54426daR11-R24) [[2]](diffhunk://#diff-b1d2bed41793d9e4d9dfd2f93334d406ed42f8098d9c4fd4627a49a6cc97aa88L2-R2)

Is this pull request a content or a code change? (Please fill in the relevant section and delete the other)

# Code change
I can confirm:
## Accessibility considerations
- [x] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [x] This change might impact accessibility and is not covered by automated aXe tests - manual testing has been performed
(If the change might impact accessibility then please add some further information here)

## Commit signing

- [x] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
