### PR TITLE
Switch staging to Temp HODigital action

### DIFF
--- a/.github/workflows/deploy-to-core-cloud.yml
+++ b/.github/workflows/deploy-to-core-cloud.yml
@@ -106,7 +106,7 @@ jobs:
         if: always()
 
       - name: Sync
-        uses: UKHomeOffice/core-cloud-static-sites-action@1.1.0
+        uses: Home-Office-Digital/core-cloud-static-sites-action-temp@1.1.0
         with:
           assume-role-arn: ${{ vars.ROLE_ARN }}
           cloudfront-distribution: ${{ vars.CLOUDFRONT_DISTRIBUTION }}

--- a/.github/workflows/deploy-to-staging-core-cloud.yml
+++ b/.github/workflows/deploy-to-staging-core-cloud.yml
@@ -106,7 +106,7 @@ jobs:
         if: always()
 
       - name: Sync
-        uses: UKHomeOffice/core-cloud-static-sites-action@1.1.0
+        uses: Home-Office-Digital/core-cloud-static-sites-action-temp@1.1.0
         with:
           assume-role-arn: ${{ vars.ROLE_ARN }}
           cloudfront-distribution: ${{ vars.CLOUDFRONT_DISTRIBUTION }}

--- a/.github/workflows/deploy-to-staging-core-cloud.yml
+++ b/.github/workflows/deploy-to-staging-core-cloud.yml
@@ -3,7 +3,7 @@ name: Deploy to Staging Core Cloud
 on:
   push:
     branches:
-      - staging/latest
+      - staging/*
 
 permissions:
   contents: read


### PR DESCRIPTION
The GitHub action for syncing the static site is being moved to the new Home-Office-Digital organisation.

This updates the deployment workfllows to use a temp version of the new action so that the current action repo can be moved to the new organisation without disrupting our abillity to deploy. Once this is merged the core cloud team will do the transfer and we'll update these actions again to use the new permanent repo.

# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [X] This change will not change layouts, page structures or anything else that might impact accessibility

## Commit signing

- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)