### PR TITLE
Switch from temp to permanent HOD repo now that repo has been migrated

### DIFF
--- a/.github/workflows/deploy-to-core-cloud.yml
+++ b/.github/workflows/deploy-to-core-cloud.yml
@@ -106,7 +106,7 @@ jobs:
         if: always()
 
       - name: Sync
-        uses: Home-Office-Digital/core-cloud-static-sites-action-temp@1.1.0
+        uses: Home-Office-Digital/core-cloud-static-sites-action@1.1.0
         with:
           assume-role-arn: ${{ vars.ROLE_ARN }}
           cloudfront-distribution: ${{ vars.CLOUDFRONT_DISTRIBUTION }}

--- a/.github/workflows/deploy-to-staging-core-cloud.yml
+++ b/.github/workflows/deploy-to-staging-core-cloud.yml
@@ -106,7 +106,7 @@ jobs:
         if: always()
 
       - name: Sync
-        uses: Home-Office-Digital/core-cloud-static-sites-action-temp@1.1.0
+        uses: Home-Office-Digital/core-cloud-static-sites-action@1.1.0
         with:
           assume-role-arn: ${{ vars.ROLE_ARN }}
           cloudfront-distribution: ${{ vars.CLOUDFRONT_DISTRIBUTION }}


### PR DESCRIPTION
The GitHub action for syncing the static site is being moved to the new Home-Office-Digital organisation.

This follows on from #697 switching to use the new permanent action repository url now that it has been migrated.

# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [X] This change will not change layouts, page structures or anything else that might impact accessibility

## Commit signing

- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)