### PR TITLE
Allow running staging deploy on a specific branch through GitHub UI

### DIFF
--- a/.github/workflows/deploy-to-staging-core-cloud.yml
+++ b/.github/workflows/deploy-to-staging-core-cloud.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - staging/*
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to deploy'
+        required: true
 
 permissions:
   contents: read
@@ -28,7 +33,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event.inputs.branch || github.sha }}
 
       - name: Setup NPM cache
         uses: actions/setup-node@v6.4.0


### PR DESCRIPTION
When another branch without the `staging/` prefix has changes that might affect deployment it would be useful to be able to manually test that the deployment changes work using the staging deployment action. Use case: dependabot updates that affect the `Home-Office-Digital/core-cloud-static-sites-action`.

# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [X] This change will not change layouts, page structures or anything else that might impact accessibility

## Commit signing

- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)