### PR TITLE
Update liquidjs to version 10.27.0 to address critical security vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2575,9 +2575,9 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.25.7",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.25.7.tgz",
-      "integrity": "sha512-rPCjJLiD4eDhQjvv964AeXFC+HbeYBbZrd7Z82Q6hqv1lX7G+5w4SJcKLn9CAAAwHI4aS3dTdo083UB79K3pDA==",
+      "version": "10.27.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.27.0.tgz",
+      "integrity": "sha512-tw/OA59K7aIBlMKIrKlumr37fiZUheShVHXY8cVctWisgY1p9mc5hreOvlreoS0wTiwlWk14Ya7305c2a/Cg5w==",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.0"


### PR DESCRIPTION
Bumped liquidjs to v10.27.0 to address npm audit critical

# Code change
I can confirm:
## Accessibility considerations
- [x] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [x] This change will not change layouts, page structures or anything else that might impact accessibility

## Commit signing

- [x] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)

