### PR TITLE
Change default review window days from 6 months to 2 years

### DIFF
--- a/.github/workflows/content-review-alerts.yml
+++ b/.github/workflows/content-review-alerts.yml
@@ -16,7 +16,7 @@ on:
       review_window_days:
         description: "Minimum age in days before content is considered overdue"
         required: true
-        default: "180"
+        default: "730"
         type: string
       max_issues_per_run:
         description: "Maximum number of new issues to create in one run (0 = no cap)"


### PR DESCRIPTION
Whilst we might want a shorter period for standards eventually - for now the review period should be longer as we don't have guild capacity to review all content every 6 months.

# Code change
I can confirm:
## Accessibility considerations
- [X] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [X] This change will not change layouts, page structures or anything else that might impact accessibility

## Commit signing

- [X] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
