### PR TITLE
chore: update review window days from 180 to 730 in workflow 

### DIFF
--- a/.github/workflows/content-review-alerts.yml
+++ b/.github/workflows/content-review-alerts.yml
@@ -39,7 +39,6 @@ jobs:
     env:
       SITE_ROOT: https://engineering.homeoffice.gov.uk
       ISSUE_LABELS: content
-      REVIEW_WINDOW_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.review_window_days || '180' }}
       # Automated runs default to dry-run unless explicitly overridden via repository variable.
       DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || vars.CONTENT_REVIEW_DRY_RUN || 'true' }}
       MAX_ISSUES_PER_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.max_issues_per_run || '10' }}
@@ -62,3 +61,4 @@ jobs:
         run: npm run content-review:scan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEW_WINDOW_DAYS: ${{ github.event_name == 'workflow_dispatch' && inputs.review_window_days || '730' }}

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ This repository includes a scheduled workflow to detect stale content and raise 
 
 - `dry_run`: `true` or `false`
   - `true` logs what would be created without opening issues
-- `review_window_days`: minimum age before content is considered overdue (default `180`)
+- `review_window_days`: minimum age before content is considered overdue (default `730`)
 - `max_issues_per_run`: safety cap on issue creation per run (default `10`, set `0` for no cap)
 
 ### Automated run defaults
@@ -88,7 +88,7 @@ This repository includes a scheduled workflow to detect stale content and raise 
 You can run the scanner locally before using the workflow:
 
 ```bash
-DRY_RUN=true REVIEW_WINDOW_DAYS=180 npm run content-review:scan
+DRY_RUN=true REVIEW_WINDOW_DAYS=730 npm run content-review:scan
 ```
 
 ### Safe rollout sequence

--- a/scripts/content-review-scan.mjs
+++ b/scripts/content-review-scan.mjs
@@ -33,7 +33,10 @@ export async function runCli({ env = process.env, stdout = console.log } = {}) {
 function parseCliConfig(env) {
   return {
     dryRun: parseBoolean(env.DRY_RUN, true),
-    reviewWindowDays: Number(env.REVIEW_WINDOW_DAYS || "730"),
+    reviewWindowDays: (() => {
+      const parsed = Number(env.REVIEW_WINDOW_DAYS ?? "730");
+      return Number.isFinite(parsed) && parsed > 0 ? parsed : 730;
+    })(),
     siteRoot: env.SITE_ROOT || "https://engineering.homeoffice.gov.uk",
     repository: env.GITHUB_REPOSITORY,
     token: env.GITHUB_TOKEN,

--- a/scripts/content-review-scan.mjs
+++ b/scripts/content-review-scan.mjs
@@ -34,7 +34,7 @@ function parseCliConfig(env) {
   return {
     dryRun: parseBoolean(env.DRY_RUN, true),
     reviewWindowDays: (() => {
-      const parsed = Number(env.REVIEW_WINDOW_DAYS ?? "730");
+      const parsed = Number(String(env.REVIEW_WINDOW_DAYS ?? "").trim() || "730");
       return Number.isFinite(parsed) && parsed >= 0 ? parsed : 730;
     })(),
     siteRoot: env.SITE_ROOT || "https://engineering.homeoffice.gov.uk",

--- a/scripts/content-review-scan.mjs
+++ b/scripts/content-review-scan.mjs
@@ -35,7 +35,7 @@ function parseCliConfig(env) {
     dryRun: parseBoolean(env.DRY_RUN, true),
     reviewWindowDays: (() => {
       const parsed = Number(env.REVIEW_WINDOW_DAYS ?? "730");
-      return Number.isFinite(parsed) && parsed > 0 ? parsed : 730;
+      return Number.isFinite(parsed) && parsed >= 0 ? parsed : 730;
     })(),
     siteRoot: env.SITE_ROOT || "https://engineering.homeoffice.gov.uk",
     repository: env.GITHUB_REPOSITORY,

--- a/scripts/content-review-scan.mjs
+++ b/scripts/content-review-scan.mjs
@@ -33,7 +33,7 @@ export async function runCli({ env = process.env, stdout = console.log } = {}) {
 function parseCliConfig(env) {
   return {
     dryRun: parseBoolean(env.DRY_RUN, true),
-    reviewWindowDays: Number(env.REVIEW_WINDOW_DAYS || "180"),
+    reviewWindowDays: Number(env.REVIEW_WINDOW_DAYS || "730"),
     siteRoot: env.SITE_ROOT || "https://engineering.homeoffice.gov.uk",
     repository: env.GITHUB_REPOSITORY,
     token: env.GITHUB_TOKEN,

--- a/scripts/content-review/scan.js
+++ b/scripts/content-review/scan.js
@@ -20,7 +20,7 @@ export async function findMarkdownFiles(dirPath) {
 
 export async function scanRepository({
   repoRoot = process.cwd(),
-  reviewWindowDays = 180,
+  reviewWindowDays = 730,
   siteRoot = "https://engineering.homeoffice.gov.uk",
   now = new Date(),
   buildIssuePayload

--- a/tests/unit/content-review-scan.test.js
+++ b/tests/unit/content-review-scan.test.js
@@ -171,3 +171,40 @@ Old`
   assert.match(lines.join("\n"), /\*\*Which content do you think should be reviewed\?\*\*/);
   assert.match(lines.join("\n"), /https:\/\/engineering\.homeoffice\.gov\.uk\/principles\/old-page\//);
 });
+
+test("runCli defaults to a 730 day review window", async () => {
+  const tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "content-review-cli-default-"));
+  const originalCwd = process.cwd();
+
+  await fs.mkdir(path.join(tempRoot, "docs", "principles"), { recursive: true });
+  await fs.mkdir(path.join(tempRoot, "docs", "standards"), { recursive: true });
+  await fs.mkdir(path.join(tempRoot, "docs", "patterns"), { recursive: true });
+
+  await fs.writeFile(
+    path.join(tempRoot, "docs", "standards", "accessibility.md"),
+    `---
+title: Accessibility
+date: 2025-08-13
+---
+Accessibility`
+  );
+
+  const lines = [];
+
+  process.chdir(tempRoot);
+
+  try {
+    await runCli({
+      env: {
+        DRY_RUN: "true",
+        NOW: "2026-07-20T00:00:00.000Z"
+      },
+      stdout: (line) => lines.push(line)
+    });
+  } finally {
+    process.chdir(originalCwd);
+  }
+
+  assert.match(lines.join("\n"), /Found 0 overdue content pages\./);
+  assert.doesNotMatch(lines.join("\n"), /docs\/standards\/accessibility\.md/);
+});


### PR DESCRIPTION
This pull request updates the default review window for detecting stale content in the content review workflow and related scripts, increasing it from 180 days to 730 days (2 years). This change affects the workflow configuration, documentation, CLI scripts, and tests to ensure consistency across the project.

# Code change
I can confirm:
## Accessibility considerations
- [ ] Please review the [accessibility checks for layout changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/layout-checks.md).

- [x] This change will not change layouts, page structures or anything else that might impact accessibility

or
- [ ] This change might impact accessibility, automated aXe tests cover the impact

or
- [ ] This change might impact accessibility and is not covered by automated aXe tests - manual testing has been performed
(If the change might impact accessibility then please add some further information here)

## Commit signing

- [x] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)

# Content change 
- [ ] Please review the [accessibility checks for content changes](https://github.com/UKHomeOffice/engineering-guidance-and-standards/blob/main/technical-docs/accessibility/content-checks.md).

I can confirm:
- [ ] Content does not include any code or configuration changes (excluding frontmatter information)
- [ ] Content meets the content standards
e.g. [Writing a principle](https://engineering.homeoffice.gov.uk/standards/writing-a-principle/) and [Writing a standard](https://engineering.homeoffice.gov.uk/standards/writing-a-standard/)
- [x] Content is suitable to open source, i.e.:
    - Content does not relate to unreleased gov policy
    - Content does not refer to anti-fraud mechanisms
    - Content does not include sensitive business logic
- [ ] Last updated date for content is correct
- [x] All commits are signed with a key that can be verified by GitHub. [GitHub guidance on signing commits](https://docs.github.com/en/enterprise-cloud@latest/authentication/managing-commit-signature-verification/signing-commits)
